### PR TITLE
Add nova-compute-ironic to rewrite rules

### DIFF
--- a/ansible/roles/common/templates/conf/filter/01-rewrite.conf.j2
+++ b/ansible/roles/common/templates/conf/filter/01-rewrite.conf.j2
@@ -3,7 +3,7 @@
     capitalize_regex_backreference yes
     rewriterule1 programname ^(cinder-api-access|cloudkitty-api-access|gnocchi-api-access|horizon-access|keystone-apache-admin-access|keystone-apache-public-access|placement-api-access|panko-api-access)$ apache_access
     rewriterule2 programname ^(aodh_wsgi_access|barbican-api|zun_api_wsgi_access)$ wsgi_access
-    rewriterule3 programname ^(nova-api|nova-compute|nova-conductor|nova-consoleauth|nova-manage|nova-novncproxy|nova-scheduler|nova-placement-api|placement-api|privsep-helper)$ openstack_python
+    rewriterule3 programname ^(nova-api|nova-compute|nova-compute-ironic|nova-conductor|nova-consoleauth|nova-manage|nova-novncproxy|nova-scheduler|nova-placement-api|placement-api|privsep-helper)$ openstack_python
     rewriterule4 programname ^(sahara-api|sahara-engine)$ openstack_python
     rewriterule5 programname ^(neutron-server|neutron-openvswitch-agent|neutron-ns-metadata-proxy|neutron-metadata-agent|neutron-l3-agent|neutron-dhcp-agent)$ openstack_python
     rewriterule6 programname ^(magnum-conductor|magnum-api)$ openstack_python


### PR DESCRIPTION
We want to treat the nova-compute-ironic log in the same way as the
other nova logs.