### PR TITLE
Standardise log field naming

### DIFF
--- a/ansible/roles/common/templates/conf/input/04-openstack-wsgi.conf.j2
+++ b/ansible/roles/common/templates/conf/input/04-openstack-wsgi.conf.j2
@@ -5,5 +5,5 @@
   path /var/log/kolla/*/*-access.log,/var/log/kolla/*/*-error.log
   pos_file /var/run/{{ fluentd_dir }}/kolla-openstack-wsgi.pos
   tag kolla.*
-  format /^(?<message>.*)$/
+  format /^(?<Payload>.*)$/
 </source>


### PR DESCRIPTION
Use the same field name for extracting all log messages to make it
simpler to parse the output from fluentd.

Closes-Bug: #1723459

Change-Id: I55b86061c8f70b25cf88e394fdfc78fa3c85c79f