### PR TITLE
Add support for --skip-tags argument

### DIFF
--- a/releasenotes/notes/skip-tags-c0a4ac3900f33e7f.yaml
+++ b/releasenotes/notes/skip-tags-c0a4ac3900f33e7f.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds a new argument to the ``kolla-ansible`` command, ``--skip-tags TAGS``.
+    This argument is passed through directly to ``ansible-playbook``.

--- a/tools/kolla-ansible
+++ b/tools/kolla-ansible
@@ -40,6 +40,7 @@ Options:
     --key -k <key_path>                Specify path to ansible vault keyfile
     --help, -h                         Show this usage information
     --tags, -t <tags>                  Only run plays and tasks tagged with these values
+    --skip-tags <tags>                 Only run plays and tasks whose tags do not match these values
     --extra, -e <ansible variables>    Set additional variables as key=value or YAML/JSON passed to ansible-playbook
     --passwords <passwords_path>       Specify path to the passwords file
     --limit <host>                     Specify host to run plays
@@ -73,6 +74,7 @@ cat <<EOF
 --configdir
 --key -k
 --help -h
+--skip-tags
 --tags -t
 --extra -e
 --passwords
@@ -97,7 +99,7 @@ EOF
 }
 
 SHORT_OPTS="hi:p:t:k:e:v"
-LONG_OPTS="help,inventory:,playbook:,tags:,key:,extra:,verbose,configdir:,passwords:,limit:,yes-i-really-really-mean-it,include-images,include-dev"
+LONG_OPTS="help,inventory:,playbook:,skip-tags:,tags:,key:,extra:,verbose,configdir:,passwords:,limit:,yes-i-really-really-mean-it,include-images,include-dev"
 ARGS=$(getopt -o "${SHORT_OPTS}" -l "${LONG_OPTS}" --name "$0" -- "$@") || { usage >&2; exit 2; }
 
 eval set -- "$ARGS"
@@ -127,6 +129,11 @@ while [ "$#" -gt 0 ]; do
 
     (--playbook|-p)
             PLAYBOOK="$2"
+            shift 2
+            ;;
+
+    (--skip-tags)
+            EXTRA_OPTS="$EXTRA_OPTS --skip-tags $2"
             shift 2
             ;;
 


### PR DESCRIPTION
This allows for skipping tasks which match the provided tags, using
the ansible-playbook argument of the same name.

This can be useful in combination with --tags, to skip reconfiguration
of the common tasks:

kolla-ansible reconfigure --tags nova --skip-tags common

Change-Id: I766552f7ae4099da3d174759f4a609ffe8b4d89f