### PR TITLE
Add hostname to all log messages

### DIFF
--- a/ansible/roles/common/templates/conf/filter/00-record_transformer.conf.j2
+++ b/ansible/roles/common/templates/conf/filter/00-record_transformer.conf.j2
@@ -10,6 +10,7 @@
 <filter infra.*>
     @type record_transformer
     <record>
+        Hostname ${hostname}
         programname ${tag_parts[1]}
     </record>
 </filter>

--- a/ansible/roles/common/templates/conf/input/01-syslog.conf.j2
+++ b/ansible/roles/common/templates/conf/input/01-syslog.conf.j2
@@ -4,5 +4,6 @@
   bind {{ api_interface_address }}
   tag syslog
   priority_key log_level
+  source_hostname_key Hostname
   format /^(?<Payload>.*)$/
 </source>


### PR DESCRIPTION
Prior to this change not all log messages from fluentd would
    contain the hostname. It was therefore difficult to tell
    which host they had originated from.

Closes-Bug: #1726596
Change-Id: I3093215720662c158d1417e15bac1bbaec3c4ab7