### PR TITLE
Extract log level from syslog

### DIFF
--- a/ansible/roles/common/templates/conf/input/01-syslog.conf.j2
+++ b/ansible/roles/common/templates/conf/input/01-syslog.conf.j2
@@ -3,5 +3,6 @@
   port {{ fluentd_syslog_port }}
   bind {{ api_interface_address }}
   tag syslog
+  priority_key log_level
   format /^(?<Payload>.*)$/
 </source>


### PR DESCRIPTION
By default the syslog input plugin won't extract the
log level from a syslog message. By setting the priority
key, the log level is extracted.

Change-Id: I9ad5f5e1c875ef62b39fbbba7b271d98cee68dd6