### PR TITLE
Add configurable rabbitmq monitoring user

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -442,6 +442,7 @@ enable_kibana: "{{ 'yes' if enable_central_logging | bool else 'no' }}"
 # RabbitMQ options
 ####################
 rabbitmq_user: "openstack"
+rabbitmq_monitoring_user: ""
 rabbitmq_version: "rabbitmq_server-3.6/plugins/rabbitmq_clusterer-3.6.x.ez/rabbitmq_clusterer-3.6.x-667f92b0/ebin"
 outward_rabbitmq_user: "openstack"
 

--- a/ansible/roles/rabbitmq/templates/definitions.json.j2
+++ b/ansible/roles/rabbitmq/templates/definitions.json.j2
@@ -5,12 +5,14 @@
     {% endif %}
   ],
   "users": [
-    {"name": "{{ role_rabbitmq_user }}", "password": "{{ role_rabbitmq_password }}", "tags": "administrator"}{% if project_name == 'outward_rabbitmq' %},
+    {"name": "{{ role_rabbitmq_user }}", "password": "{{ role_rabbitmq_password }}", "tags": "administrator"}{% if role_rabbitmq_monitoring_user is defined and role_rabbitmq_monitoring_user %},
+    {"name": "{{ role_rabbitmq_monitoring_user }}", "password": "{{ role_rabbitmq_monitoring_password }}", "tags": "monitoring"}{% endif %}{% if project_name == 'outward_rabbitmq' %},
     {"name": "{{ murano_agent_rabbitmq_user }}", "password": "{{ murano_agent_rabbitmq_password }}", "tags": "management"}
     {% endif %}
   ],
   "permissions": [
-    {"user": "{{ role_rabbitmq_user }}", "vhost": "/", "configure": ".*", "write": ".*", "read": ".*"}{% if project_name == 'outward_rabbitmq' %},
+    {"user": "{{ role_rabbitmq_user }}", "vhost": "/", "configure": ".*", "write": ".*", "read": ".*"}{% if role_rabbitmq_monitoring_user is defined and role_rabbitmq_monitoring_user %},
+    {"user": "{{ role_rabbitmq_monitoring_user }}", "vhost": "/", "configure": "^$", "write": "^$", "read": ".*"}{% endif %}{% if project_name == 'outward_rabbitmq' %},
     {"user": "{{ murano_agent_rabbitmq_user }}", "vhost": "{{ murano_agent_rabbitmq_vhost }}", "configure": ".*", "write": ".*", "read": ".*"}
     {% endif %}
   ],

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -180,6 +180,8 @@
         role_rabbitmq_epmd_port: '{{ rabbitmq_epmd_port }}',
         role_rabbitmq_groups: rabbitmq,
         role_rabbitmq_management_port: '{{ rabbitmq_management_port }}',
+        role_rabbitmq_monitoring_password: '{{ rabbitmq_monitoring_password }}',
+        role_rabbitmq_monitoring_user: '{{ rabbitmq_monitoring_user }}',
         role_rabbitmq_password: '{{ rabbitmq_password }}',
         role_rabbitmq_port: '{{ rabbitmq_port }}',
         role_rabbitmq_user: '{{ rabbitmq_user }}',

--- a/etc/kolla/passwords.yml
+++ b/etc/kolla/passwords.yml
@@ -190,6 +190,7 @@ qdrouterd_password:
 # RabbitMQ options
 ####################
 rabbitmq_password:
+rabbitmq_monitoring_password:
 rabbitmq_cluster_cookie:
 outward_rabbitmq_password:
 outward_rabbitmq_cluster_cookie:

--- a/releasenotes/notes/bp-add-monitoring-user-for-rabbit-d869cddde8e8c5f3.yaml
+++ b/releasenotes/notes/bp-add-monitoring-user-for-rabbit-d869cddde8e8c5f3.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    Kolla-Ansible now supports creating a monitoring
+    user for RabbitMQ.
+    The monitoring user has read only access to the
+    openstack vhost and is tagged with the 'monitoring'
+    tag which allows it to report node-level information
+    such as system resource usage. By default the
+    monitoring user is disabled. To create it, the user
+    should override the rabbitmq_monitoring_user variable.


### PR DESCRIPTION
This change allows the operator to optionally configure a monitoring
user in rabbit, who has read only access to the openstack vhost.

Implements: blueprint add-monitoring-user-for-rabbit
Change-Id: Ie895ddc59dda1c38faab6305163d9bed6710ff9d