### PR TITLE
Horizon multidomain flag

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -577,6 +577,7 @@ murano_agent_rabbitmq_user: "muranoagent"
 # Horizon options
 #######################
 horizon_backend_database: "{{ enable_murano | bool }}"
+horizon_keystone_multidomain: False
 
 
 #################

--- a/ansible/roles/horizon/templates/local_settings.j2
+++ b/ansible/roles/horizon/templates/local_settings.j2
@@ -87,7 +87,7 @@ OPENSTACK_API_VERSIONS = {
 # Set this to True if running on a multi-domain model. When this is enabled, it
 # will require the user to enter the Domain name in addition to the username
 # for login.
-#OPENSTACK_KEYSTONE_MULTIDOMAIN_SUPPORT = False
+OPENSTACK_KEYSTONE_MULTIDOMAIN_SUPPORT = {{ horizon_keystone_multidomain | bool }}
 
 # Overrides the default domain used when running on single-domain model
 # with Keystone V3. All entities will be created in the default domain.

--- a/releasenotes/notes/horizon_keystone_multidomain-c7a80d670f3654d8.yaml
+++ b/releasenotes/notes/horizon_keystone_multidomain-c7a80d670f3654d8.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Added horizon_keystone_multidomain flag for horizon multidomain support.
+    This flag can be overriden in globals.yml. Default value: False


### PR DESCRIPTION
Added horizon_keystone_multidomain flag. It can be now overriden
in globals.yml. Default set to False.

Change-Id: I6f8f261cf4b9779e57c2443ac219cdddb1731f52