### PR TITLE
Fix ironic inspector public endpoint

### DIFF
--- a/ansible/roles/ironic/defaults/main.yml
+++ b/ansible/roles/ironic/defaults/main.yml
@@ -50,8 +50,8 @@ ironic_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn }}:{
 ironic_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn }}:{{ ironic_api_port }}"
 
 ironic_inspector_admin_endpoint: "{{ admin_protocol }}://{{ kolla_internal_fqdn }}:{{ ironic_inspector_port }}"
-ironic_inspector_internal_endpoint: "{{ admin_protocol }}://{{ kolla_internal_fqdn }}:{{ ironic_inspector_port }}"
-ironic_inspector_public_endpoint: "{{ admin_protocol }}://{{ kolla_internal_fqdn }}:{{ ironic_inspector_port }}"
+ironic_inspector_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn }}:{{ ironic_inspector_port }}"
+ironic_inspector_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn }}:{{ ironic_inspector_port }}"
 
 ironic_logging_debug: "{{ openstack_logging_debug }}"
 

--- a/ansible/roles/ironic/tasks/reconfigure.yml
+++ b/ansible/roles/ironic/tasks/reconfigure.yml
@@ -1,4 +1,9 @@
 ---
+- include: register.yml
+  when: enable_keystone | bool and
+        (inventory_hostname in groups['ironic-api'] or
+        inventory_hostname in groups['ironic-inspector'])
+
 - name: Ensuring the containers up
   kolla_docker:
     name: "{{ item.name }}"

--- a/ansible/roles/ironic/tasks/upgrade.yml
+++ b/ansible/roles/ironic/tasks/upgrade.yml
@@ -1,4 +1,9 @@
 ---
+- include: register.yml
+  when: enable_keystone | bool and
+        (inventory_hostname in groups['ironic-api'] or
+        inventory_hostname in groups['ironic-inspector'])
+
 - include: config.yml
 
 - include: bootstrap_service.yml

--- a/ansible/roles/ironic/templates/ironic.conf.j2
+++ b/ansible/roles/ironic/templates/ironic.conf.j2
@@ -82,6 +82,7 @@ user_domain_id = default
 project_name = service
 username = {{ ironic_keystone_user }}
 password = {{ ironic_keystone_password }}
+service_url = {{ ironic_inspector_internal_endpoint }}
 
 [agent]
 deploy_logs_local_path = /var/log/kolla/ironic

--- a/releasenotes/notes/inspector-public-endpoint-61e0adc37f882a64.yaml
+++ b/releasenotes/notes/inspector-public-endpoint-61e0adc37f882a64.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes a bug where the Baremetal Introspection service's public endpoint
+    registered in the Identity service referenced the internal API endpoint.


### PR DESCRIPTION
Fixes a bug where the Baremetal Introspection service's public endpoint
registered in the Identity service referenced the internal API endpoint.

Change-Id: I32d475f288bb4a3834c13cc86f0c53b5437c3d25
Closes-Bug: #1738418
(cherry picked from commit f45d081c37ce9af97bbb49fde53ba0f911ea36f0)