### PR TITLE
Local connection to remote Grafana can fail

### DIFF
--- a/ansible/roles/grafana/tasks/post_config.yml
+++ b/ansible/roles/grafana/tasks/post_config.yml
@@ -4,11 +4,10 @@
     url: "{{ internal_protocol }}://{{ kolla_internal_vip_address }}:{{ grafana_server_port }}/login"
     status_code: 200
   register: result
-  until: result.status == 200
+  until: result | failed or result.status == 200
   retries: 10
   delay: 2
   run_once: true
-  connection: local
 
 - name: Enable grafana datasources
   uri:
@@ -22,7 +21,6 @@
     status_code: 200, 409
   register: response
   run_once: True
-  connection: local
   changed_when: response.status == 200
   failed_when: response.status not in [200, 409] or
                response.status == 409 and ("Data source with same name already exists" not in response.json.message|default(""))
@@ -40,5 +38,4 @@
   register: grafana_response
   changed_when: grafana_response.status == 200
   run_once: true
-  connection: local
   when: grafana_custom_dashboard_file.stat.exists


### PR DESCRIPTION
Following deployment of Grafana, a check is made to ensure that the
login page is accessible. If the Grafana container has been deployed
to a remote host, but is not directly accessible over the deployment
network then the check will fail because the task is set to run with
connection: local. For example, if Ansible is using a different
network to the network on which grafana is exposed to connect to the
remote host then the task may fail. A similar problem exists for the
remaining two tasks in the post_config file.

Further to this, if Grafana is not accessible, the ansible uri
module does not return a status field, so no retry attempts are made
and the task fails with an obscure message:

TASK [grafana : Wait for grafana application ready] *****************
fatal: [some_remote_node]: FAILED! => {"failed": true, "msg": "The
conditional check 'result.status == 200' failed. The error was: error
while evaluating conditional (result.status == 200): 'dict object' has
no attribute 'status'"}

$ ansible --version
ansible 2.3.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Aug 4 2017, 00:39:18) [GCC 4.8.5 20150623
(Red Hat 4.8.5-16)]

Change-Id: I77e2129b4a1c5f2f0802fb92eb03395ff72cf5f3
Closes-Bug: #1742501