### PR TITLE
Fix retry mechanism

### DIFF
--- a/ansible/roles/grafana/tasks/post_config.yml
+++ b/ansible/roles/grafana/tasks/post_config.yml
@@ -4,7 +4,7 @@
     url: "{{ internal_protocol }}://{{ kolla_internal_vip_address }}:{{ grafana_server_port }}/login"
     status_code: 200
   register: result
-  until: result | failed or result.status == 200
+  until: result.get('status') == 200
   retries: 10
   delay: 2
   run_once: true


### PR DESCRIPTION
I should have tested this more carefully. It also seems that the ansible module sets ```status=-1``` if it can't connect to the endpoint. I haven't figured out why that wasn't happening before - I'm using the same version of ansible.

Commit message:

If the wrong status code is returned, ansible sets failed: true.
This means that a retry is never attempted.

Closes-Bug: #1742501