### PR TITLE
Support configuring grafana local admin username

### DIFF
--- a/ansible/roles/grafana/defaults/main.yml
+++ b/ansible/roles/grafana/defaults/main.yml
@@ -52,3 +52,4 @@ grafana_data_sources:
 grafana_image: "{{ docker_registry ~ '/' if docker_registry else '' }}{{ docker_namespace }}/{{ kolla_base_distro }}-{{ kolla_install_type }}-grafana"
 grafana_tag: "{{ openstack_release }}"
 grafana_image_full: "{{ grafana_image }}:{{ grafana_tag }}"
+grafana_admin_username: "admin"

--- a/ansible/roles/grafana/tasks/post_config.yml
+++ b/ansible/roles/grafana/tasks/post_config.yml
@@ -13,7 +13,7 @@
   uri:
     url: "{{ internal_protocol }}://{{ kolla_internal_vip_address }}:{{ grafana_server_port }}/api/datasources"
     method: POST
-    user: admin
+    user: "{{ grafana_admin_username }}"
     password: "{{ grafana_admin_password }}"
     body: "{{ item.value.data | to_json }}"
     body_format: json
@@ -31,7 +31,7 @@
   uri:
     url: "{{ internal_protocol }}://{{ kolla_internal_vip_address }}:{{ grafana_server_port }}/api/user/helpflags/1"
     method: PUT
-    user: admin
+    user: "{{ grafana_admin_username }}"
     password: "{{ grafana_admin_password }}"
     force_basic_auth: yes
     status_code: 200

--- a/ansible/roles/grafana/templates/grafana.ini.j2
+++ b/ansible/roles/grafana/templates/grafana.ini.j2
@@ -35,5 +35,5 @@ reporting_enabled = false
 check_for_updates = false
 
 [security]
-admin_user = admin
+admin_user = {{ grafana_admin_username }}
 admin_password = {{ grafana_admin_password }}


### PR DESCRIPTION
The grafana local admin username can be configured by overriding
the admin user field in the grafana.ini file. However, this will
fail when kolla-ansible attempts to configure any enabled
datasources for grafana because the local admin password is
hardcoded to 'admin'. This change allows the grafana local admin
password to be configured via group vars so that the correct
username is used when configuring datasources.

Change-Id: I0962200894f7a0452da1c249a68f9230b6fab13f