### PR TITLE
Dont use local connection for kibana post config

### DIFF
--- a/ansible/roles/kibana/tasks/post_config.yml
+++ b/ansible/roles/kibana/tasks/post_config.yml
@@ -4,7 +4,6 @@
     host: "{{ kolla_internal_vip_address }}"
     port: "{{ kibana_server_port }}"
   run_once: true
-  connection: local
 
 - name: Wait for kibana to register in elasticsearch
   uri:
@@ -15,7 +14,6 @@
   retries: 5
   delay: 2
   run_once: true
-  connection: local
 
 - name: Get kibana default indexes
   uri:
@@ -24,7 +22,6 @@
     method: GET
   register: kibana_default_indexes
   run_once: true
-  connection: local
   when: kibana_default_index is defined
 
 - name: Set kibana default indexes fact
@@ -43,7 +40,6 @@
     body_format: json
     status_code: 201
   run_once: true
-  connection: local
   when:
     - kibana_default_index is defined
     - kibana_default_indexes is defined
@@ -77,7 +73,6 @@
     body_format: json
     status_code: 200
   run_once: true
-  connection: local
   when:
     - kibana_default_index is defined
     - kibana_default_indexes is defined


### PR DESCRIPTION
Backport of upstream bug causing issues when deploying Kibana:

We should not assume the VIP is accessible from the deploy node.

Change-Id: I39640f98b4adddb9cb8dfdd09d9fb7ecba15a820
Closes-Bug: #1730651