### PR TITLE
Use Elasticsearch via HAProxy in Kibana

### DIFF
--- a/ansible/roles/kibana/templates/kibana.yml.j2
+++ b/ansible/roles/kibana/templates/kibana.yml.j2
@@ -2,7 +2,7 @@ kibana.defaultAppId: "{{ kibana_default_app_id }}"
 logging.dest: /var/log/kolla/kibana/kibana.log
 server.port: {{ kibana_server_port }}
 server.host: "{{ api_interface_address }}"
-elasticsearch.url: "{{ internal_protocol }}://{{ hostvars[inventory_hostname]['ansible_' + api_interface]['ipv4']['address'] }}:{{ elasticsearch_port }}"
+elasticsearch.url: "{{ internal_protocol }}://{{ kolla_internal_vip_address }}:{{ elasticsearch_port }}"
 elasticsearch.requestTimeout: {{ kibana_elasticsearch_request_timeout }}
 elasticsearch.shardTimeout: {{ kibana_elasticsearch_shard_timeout }}
 elasticsearch.ssl.verify: {{ kibana_elasticsearch_ssl_verify }}


### PR DESCRIPTION
The original code assumes that ElasticSearch will be deployed
on the same node as Kibana. This isn't always the case. When
they are not on the same node, Kibana will not be able to
connect to ElasticSearch and deployment will fail on the task:
'kibana : Wait for kibana to register in elasticsearch'.

A second advantage of making this change is that Kibana won't
break if ElasticSearch goes down on the node that it's running on
when there are additional ElasticSearch instances on other nodes.

A disadvantage of this change is that queries from Kibana to
ElasticSearch will no longer be local.

Change-Id: I02ab2e7b1eb963b33e29c8f649cc9db0d63316f7