### PR TITLE
Zookeeper: Fix template issue

### DIFF
--- a/ansible/roles/zookeeper/templates/zookeeper.cfg.j2
+++ b/ansible/roles/zookeeper/templates/zookeeper.cfg.j2
@@ -4,5 +4,5 @@ syncLimit=5
 dataDir=/var/lib/zookeeper/data
 clientPort={{ zookeeper_client_port }}
 {% for host in groups['zookeeper'] -%}
-server.{{ loop.index }}={{ hostvars[host]['api_interface_address'] }}:{{ zookeeper_peer_port }}:{{ zookeeper_quorum_port }}
+server.{{ loop.index }}={{ hostvars[host]['ansible_' + hostvars[host]['api_interface']]['ipv4']['address'] }}:{{ zookeeper_peer_port }}:{{ zookeeper_quorum_port }}
 {%- endfor %}


### PR DESCRIPTION
The line: ```hostvars[host]['api_interface_address']``` templates to:

```hostvars[inventory_hostname]['ansible_' + api_interface]['ipv4']['address']```

which is actually what we want to render.