### PR TITLE
Fix Zookeeper config file when multiple hosts are used

### DIFF
--- a/ansible/roles/zookeeper/templates/zookeeper.cfg.j2
+++ b/ansible/roles/zookeeper/templates/zookeeper.cfg.j2
@@ -3,6 +3,6 @@ initLimit=10
 syncLimit=5
 dataDir=/var/lib/zookeeper/data
 clientPort={{ zookeeper_client_port }}
-{% for host in groups['zookeeper'] -%}
+{% for host in groups['zookeeper'] %}
 server.{{ loop.index }}={{ hostvars[host]['ansible_' + hostvars[host]['api_interface']]['ipv4']['address'] }}:{{ zookeeper_peer_port }}:{{ zookeeper_quorum_port }}
-{%- endfor %}
+{% endfor %}


### PR DESCRIPTION
Previously Jinja stripped of the new line for each server.
This change creates a config file where the servers
are each on their own line. For example:

tickTime = 2000
initLimit = 10
syncLimit = 5
dataDir = /var/lib/zookeeper/data
clientPort = 2181
server.1 = 10.11.12.13:2888:3888
server.2 = 10.11.12.13:2888:3888

Change-Id: I0b4b351561f964f8d7f329e1f6c2920c805d4c49