### PR TITLE
kolla-ansible fix to correct magnum k8s deployment

### DIFF
--- a/ansible/roles/heat/templates/heat.conf.j2
+++ b/ansible/roles/heat/templates/heat.conf.j2
@@ -73,7 +73,7 @@ password = {{ heat_keystone_password }}
 auth_uri = {{ internal_protocol }}://{{ kolla_internal_fqdn }}:{{ keystone_public_port }}/v3
 
 [clients_keystone]
-auth_uri = {{ internal_protocol }}://{{ kolla_internal_fqdn }}:{{ keystone_public_port }}
+auth_uri = {{ public_protocol }}://{{ kolla_external_fqdn }}:{{ keystone_public_port }}
 
 [oslo_messaging_notifications]
 {% if enable_ceilometer | bool %}


### PR DESCRIPTION
Magnum was unable to fire up k8s cluster because heat-container-agent
inside kube-master was pointing to internal keystone endpoint instead of
public endpoint. This fix tells kolla ansible to set clients_keystone
auth_uri to public endpoint so that heat-container-agent communication
with heat is successfully authenticated by keystone.

Change-Id: Ida49528f88685710b5e6b8f3c4d4622506af5ae1