### PR TITLE
[elasticsearch] Change ES_HEAP_SIZE  to ES_JAVA_OPTS.

### DIFF
--- a/ansible/roles/elasticsearch/defaults/main.yml
+++ b/ansible/roles/elasticsearch/defaults/main.yml
@@ -6,7 +6,7 @@ elasticsearch_services:
     enabled: true
     image: "{{ elasticsearch_image_full }}"
     environment:
-      ES_HEAP_SIZE: "{{ es_heap_size }}"
+      ES_JAVA_OPTS: "{{ es_java_opts }}"
     volumes:
       - "{{ node_config_directory }}/elasticsearch/:{{ container_config_directory }}/"
       - "/etc/localtime:/etc/localtime:ro"
@@ -18,6 +18,7 @@ elasticsearch_services:
 ####################
 elasticsearch_cluster_name: "kolla_logging"
 es_heap_size: "1g"
+es_java_opts: "{% if es_heap_size %}-Xms{{ es_heap_size }} -Xmx{{ es_heap_size }}{%endif%}"
 
 ####################
 # Docker


### PR DESCRIPTION
After enabling the elasticsearch debian/ubuntu
images the container doesn't starts with ELK 5.4.1
as ES_HEAP_SIZE has been deprecated.

We should use ES_JAVA_OPTS with the -Xms/Xmx options instead.

Closes-Bug: #1772482

Change-Id: I9b368468d41421d679a9c4ad6fdf595863de7a1a
Signed-off-by: Jorge Niedbalski <jorge.niedbalski@linaro.org>