### PR TITLE
Add Elasticsearch config for log-query-api

### DIFF
--- a/ansible/roles/monasca/defaults/main.yml
+++ b/ansible/roles/monasca/defaults/main.yml
@@ -44,6 +44,7 @@ monasca_delegate_authorized_roles:
 
 monasca_kafka: "{% for host in groups['kafka'] %}{{ hostvars[host]['ansible_' + hostvars[host]['api_interface']]['ipv4']['address'] }}:{{ kafka_port }}{% if not loop.last %},{% endif %}{% endfor %}"
 monasca_memcached_servers: "{% for host in groups['memcached'] %}{{ hostvars[host]['ansible_' + hostvars[host]['api_interface']]['ipv4']['address'] }}:{{ memcached_port }}{% if not loop.last %},{% endif %}{% endfor %}"
+monasca_elasticsearch_servers: "{% for host in groups['elasticsearch'] %}{{ internal_protocol }}://{{ hostvars[host]['ansible_' + hostvars[host]['api_interface']]['ipv4']['address'] }}:{{ elasticsearch_port }}{% if not loop.last %},{% endif %}{% endfor %}"
 
 ####################
 # Docker

--- a/ansible/roles/monasca/templates/monasca-log-api/log-api.conf.j2
+++ b/ansible/roles/monasca/templates/monasca-log-api/log-api.conf.j2
@@ -3,6 +3,9 @@ log_file = monasca-log-api.log
 log_dir = /var/log/kolla/monasca
 debug = {{ monasca_logging_debug }}
 
+[service]
+region = {{ openstack_region_name }}
+
 [kafka_healthcheck]
 kafka_url = {{ monasca_kafka }}
 
@@ -33,3 +36,6 @@ service_token_roles_required=True
 memcache_security_strategy = ENCRYPT
 memcache_secret_key = {{ memcache_secret_key }}
 memcached_servers = {{ monasca_memcached_servers }}
+
+[elasticsearch]
+uris = {{ monasca_elasticsearch_servers }}


### PR DESCRIPTION
This one can go upstream once support is merged for the log-query-api.