### PR TITLE
Allow nova to use cephfs cinder volumes without nova cephfs backend

### DIFF
--- a/ansible/roles/nova/tasks/deploy.yml
+++ b/ansible/roles/nova/tasks/deploy.yml
@@ -12,7 +12,7 @@
 
 - include: external_ceph.yml
   when:
-    - not enable_ceph | bool and nova_backend == "rbd"
+    - not enable_ceph | bool and (nova_backend == "rbd" or cinder_backend_ceph | bool)
     - inventory_hostname in groups['compute']
 
 - include: register.yml

--- a/ansible/roles/nova/tasks/external_ceph.yml
+++ b/ansible/roles/nova/tasks/external_ceph.yml
@@ -14,7 +14,9 @@
   run_once: True
   register: nova_cephx_keyring_file
   failed_when: not nova_cephx_keyring_file.stat.exists
-  when: external_ceph_cephx_enabled | bool
+  when:
+    - nova_backend == "rbd"
+    - external_ceph_cephx_enabled | bool
 
 - name: Check cinder keyring file
   local_action: stat path="{{ node_custom_config }}/nova/ceph.client.cinder.keyring"
@@ -36,6 +38,7 @@
     - nova-libvirt
   when:
     - inventory_hostname in groups['compute']
+    - nova_backend == "rbd"
     - external_ceph_cephx_enabled | bool
   notify:
     - Restart nova-compute container
@@ -49,7 +52,9 @@
   with_items:
     - nova-compute
     - nova-libvirt
-  when: inventory_hostname in groups['compute']
+  when:
+    - inventory_hostname in groups['compute']
+    - nova_backend == "rbd"
   notify:
     - Restart nova-compute container
     - Restart nova-libvirt container
@@ -65,7 +70,7 @@
   with_items:
     - uuid: "{{ rbd_secret_uuid }}"
       name: "client.nova secret"
-      enabled: true
+      enabled: "{{ nova_backend == 'rbd' }}"
     - uuid: "{{ cinder_rbd_secret_uuid }}"
       name: "client.cinder secret"
       enabled: "{{ cinder_backend_ceph }}"
@@ -76,7 +81,9 @@
   local_action: shell cat "{{ nova_cephx_keyring_file.stat.path }}" | grep -E 'key\s*=' | awk '{ print $3 }'
   run_once: True
   register: nova_cephx_raw_key
-  when: external_ceph_cephx_enabled | bool
+  when:
+    - nova_backend == "rbd"
+    - external_ceph_cephx_enabled | bool
 
 - name: Extract cinder key from file
   local_action: shell cat "{{ cinder_cephx_keyring_file.stat.path }}" | grep -E 'key\s*=' | awk '{ print $3 }'
@@ -88,7 +95,7 @@
 
 - name: Pushing secrets key for libvirt
   copy:
-    content: "{{ item.content }}"
+    content: "{{ item.result.stdout }}"
     dest: "{{ node_config_directory }}/nova-libvirt/secrets/{{ item.uuid }}.base64"
     mode: "0600"
   when:
@@ -97,10 +104,10 @@
     - external_ceph_cephx_enabled | bool
   with_items:
     - uuid: "{{ rbd_secret_uuid }}"
-      content: "{{ nova_cephx_raw_key.stdout }}"
-      enabled: true
+      result: "{{ nova_cephx_raw_key }}"
+      enabled: "{{ nova_backend == 'rbd' }}"
     - uuid: "{{ cinder_rbd_secret_uuid }}"
-      content: "{{ cinder_cephx_raw_key.stdout }}"
+      result: "{{ cinder_cephx_raw_key }}"
       enabled: "{{ cinder_backend_ceph }}"
   notify:
     - Restart nova-libvirt container

--- a/ansible/roles/nova/templates/nova-libvirt.json.j2
+++ b/ansible/roles/nova/templates/nova-libvirt.json.j2
@@ -12,13 +12,13 @@
             "dest": "/etc/libvirt/qemu.conf",
             "owner": "root",
             "perm": "0600"
-        }{% if nova_backend == "rbd" %},
+        }{% if nova_backend == "rbd" or cinder_backend_ceph | bool %},
         {
             "source": "{{ container_config_directory }}/secrets",
             "dest": "/etc/libvirt/secrets",
             "owner": "root",
             "perm": "0600"
-        },
+        }{% endif %}{% if nova_backend == "rbd" %},
         {
             "source": "{{ container_config_directory }}/ceph.conf",
             "dest": "/etc/ceph/ceph.conf",


### PR DESCRIPTION
Changes for using nova with cinder without using the nova cephs backend