### PR TITLE
Add support for enabling ipxe boot with ironic (#29)

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -207,6 +207,7 @@ influxdb_http_port: "8086"
 
 ironic_api_port: "6385"
 ironic_inspector_port: "5050"
+ironic_ipxe_port: "8089"
 
 iscsi_port: "3260"
 
@@ -435,6 +436,7 @@ enable_horizon_zun: "{{ enable_zun | bool }}"
 enable_hyperv: "no"
 enable_influxdb: "{{ enable_monasca | bool }}"
 enable_ironic: "no"
+enable_ironic_ipxe: "no"
 enable_ironic_pxe_uefi: "no"
 enable_iscsid: "{{ (enable_cinder | bool and enable_cinder_backend_iscsi | bool) or enable_ironic | bool }}"
 enable_karbor: "no"

--- a/ansible/inventory/all-in-one
+++ b/ansible/inventory/all-in-one
@@ -449,6 +449,9 @@ ironic
 [ironic-pxe:children]
 ironic
 
+[ironic-ipxe:children]
+ironic
+
 # Magnum
 [magnum-api:children]
 magnum

--- a/ansible/inventory/multinode
+++ b/ansible/inventory/multinode
@@ -458,6 +458,9 @@ ironic
 [ironic-pxe:children]
 ironic
 
+[ironic-ipxe:children]
+ironic
+
 # Magnum
 [magnum-api:children]
 magnum

--- a/ansible/roles/ironic/defaults/main.yml
+++ b/ansible/roles/ironic/defaults/main.yml
@@ -68,3 +68,4 @@ ironic_dnsmasq_interface: "{{ api_interface }}"
 ironic_dnsmasq_dhcp_range:
 ironic_cleaning_network:
 ironic_console_serial_speed: "115200n8"
+ironic_ipxe_url: http://{{ api_interface_address }}:{{ ironic_ipxe_port }}

--- a/ansible/roles/ironic/tasks/config.yml
+++ b/ansible/roles/ironic/tasks/config.yml
@@ -9,6 +9,7 @@
     - "ironic-conductor"
     - "ironic-inspector"
     - "ironic-pxe"
+    - "ironic-ipxe"
     - "ironic-dnsmasq"
 
 - name: Check if policies shall be overwritten
@@ -37,6 +38,7 @@
     - "ironic-conductor"
     - "ironic-inspector"
     - "ironic-pxe"
+    - "ironic-ipxe"
     - "ironic-dnsmasq"
 
 - name: Copying over ironic.conf
@@ -90,6 +92,7 @@
     - groups['ironic-inspector'] | length > 0
     - inventory_hostname in groups['ironic-pxe']
     - not enable_ironic_pxe_uefi | bool
+    - not enable_ironic_ipxe | bool
 
 - name: Copying ironic_pxe_uefi.cfg default
   template:
@@ -103,7 +106,7 @@
     - inventory_hostname in groups['ironic-pxe']
     - enable_ironic_pxe_uefi | bool
 
-- name: Copying ironic-agent kernel and initramfs
+- name: Copying ironic-agent kernel and initramfs (PXE)
   copy:
     src: "{{ node_custom_config }}/ironic/{{ item }}"
     dest: "{{ node_config_directory }}/ironic-pxe/{{ item }}"
@@ -115,6 +118,45 @@
     - groups['ironic-inspector'] | length > 0
     - inventory_hostname in groups['ironic-pxe']
     - not enable_ironic_pxe_uefi | bool
+    - not enable_ironic_ipxe | bool
+
+- name: Copying ironic-agent kernel and initramfs (iPXE)
+  copy:
+    src: "{{ node_custom_config }}/ironic/{{ item }}"
+    dest: "{{ node_config_directory }}/ironic-ipxe/{{ item }}"
+  with_items:
+    - "ironic-agent.kernel"
+    - "ironic-agent.initramfs"
+  when:
+    # Only required when Ironic inspector is in use.
+    - groups['ironic-inspector'] | length > 0
+    - inventory_hostname in groups['ironic-ipxe']
+    - enable_ironic_ipxe | bool
+
+- name: Copying inspector.ipxe
+  template:
+    src: "{{ item }}"
+    dest: "{{ node_config_directory }}/ironic-ipxe/inspector.ipxe"
+  with_first_found:
+    - "{{ node_custom_config }}/ironic/{{ inventory_hostname }}/inspector.ipxe"
+    - "{{ node_custom_config }}/ironic/inspector.ipxe"
+    - "inspector.ipxe.j2"
+  when:
+    # Only required when Ironic inspector is in use.
+    - groups['ironic-inspector'] | length > 0
+    - inventory_hostname in groups['ironic-ipxe']
+    - enable_ironic_ipxe | bool
+
+- name: Copying httpd config
+  template:
+    src: "{{ item }}"
+    dest: "{{ node_config_directory }}/ironic-ipxe/httpd.conf"
+  with_first_found:
+    - "{{ node_custom_config }}/ironic/ironic-ipxe-httpd.conf"
+    - "ironic-ipxe-httpd.conf.j2"
+  when:
+    - enable_ironic_ipxe | bool
+    - inventory_hostname in groups['ironic-ipxe']
 
 - name: Copying over existing policy file
   template:

--- a/ansible/roles/ironic/tasks/deploy.yml
+++ b/ansible/roles/ironic/tasks/deploy.yml
@@ -8,7 +8,8 @@
   when: inventory_hostname in groups['ironic-api'] or
         inventory_hostname in groups['ironic-conductor'] or
         inventory_hostname in groups['ironic-inspector'] or
-        inventory_hostname in groups['ironic-pxe']
+        inventory_hostname in groups['ironic-pxe'] or
+        inventory_hostname in groups['ironic-ipxe']
 
 - include: bootstrap.yml
   when: inventory_hostname in groups['ironic-api'] or
@@ -18,4 +19,5 @@
   when: inventory_hostname in groups['ironic-api'] or
         inventory_hostname in groups['ironic-conductor'] or
         inventory_hostname in groups['ironic-inspector'] or
-        inventory_hostname in groups['ironic-pxe']
+        inventory_hostname in groups['ironic-pxe'] or
+        inventory_hostname in groups['ironic-ipxe']

--- a/ansible/roles/ironic/tasks/precheck.yml
+++ b/ansible/roles/ironic/tasks/precheck.yml
@@ -4,6 +4,7 @@
     name:
       - ironic_api
       - ironic_inspector
+      - ironic_ipxe
   register: container_facts
 
 - name: Checking free port for Ironic API
@@ -28,6 +29,18 @@
     - container_facts['ironic_inspector'] is not defined
     - inventory_hostname in groups['ironic-inspector']
 
+- name: Checking free port for Ironic iPXE
+  wait_for:
+    host: "{{ api_interface_address }}"
+    port: "{{ ironic_ipxe_port }}"
+    connect_timeout: 1
+    timeout: 1
+    state: stopped
+  when:
+    - enable_ironic_ipxe | bool
+    - container_facts['ironic_ipxe'] is not defined
+    - inventory_hostname in groups['ironic-ipxe']
+
 - name: Checking ironic-agent files exist for Ironic Inspector
   local_action: stat path="{{ node_custom_config }}/ironic/{{ item }}"
   run_once: True
@@ -36,7 +49,8 @@
   when:
     # Only required when Ironic inspector is in use.
     - groups['ironic-inspector'] | length > 0
-    - inventory_hostname in groups['ironic-pxe']
+    - (not enable_ironic_ipxe | bool and inventory_hostname in groups['ironic-pxe']) or
+        (enable_ironic_ipxe | bool and inventory_hostname in groups['ironic-ipxe'])
     - not enable_ironic_pxe_uefi | bool
   with_items:
     - "ironic-agent.kernel"

--- a/ansible/roles/ironic/tasks/pull.yml
+++ b/ansible/roles/ironic/tasks/pull.yml
@@ -32,4 +32,4 @@
     action: "pull_image"
     common_options: "{{ docker_common_options }}"
     image: "{{ ironic_pxe_image_full }}"
-  when: inventory_hostname in groups['ironic-pxe']
+  when: inventory_hostname in groups['ironic-pxe'] or inventory_hostname in groups['ironic-ipxe']

--- a/ansible/roles/ironic/tasks/reconfigure.yml
+++ b/ansible/roles/ironic/tasks/reconfigure.yml
@@ -10,9 +10,12 @@
     action: "get_container_state"
   register: container_state
   failed_when: container_state.Running == false
-  when: inventory_hostname in groups[item.group]
+  when:
+    - inventory_hostname in groups[item.group]
+    - item.enabled | default(true)
   with_items:
     - { name: ironic_pxe, group: ironic-pxe }
+    - { name: ironic_ipxe, group: ironic-ipxe, enabled: "{{ enable_ironic_ipxe | bool }}" }
     - { name: ironic_api, group: ironic-api }
     - { name: ironic_conductor, group: ironic-conductor }
     - { name: ironic_inspector, group: ironic-inspector }
@@ -25,9 +28,12 @@
   changed_when: false
   failed_when: false
   register: check_results
-  when: inventory_hostname in groups[item.group]
+  when:
+    - inventory_hostname in groups[item.group]
+    - item.enabled | default(true)]
   with_items:
     - { name: ironic_pxe, group: ironic-pxe }
+    - { name: ironic_ipxe, group: ironic-ipxe, enabled: "{{ enable_ironic_ipxe | bool }}" }
     - { name: ironic_api, group: ironic-api }
     - { name: ironic_conductor, group: ironic-conductor }
     - { name: ironic_inspector, group: ironic-inspector }
@@ -38,9 +44,12 @@
     name: "{{ item.name }}"
     action: "get_container_env"
   register: container_envs
-  when: inventory_hostname in groups[item.group]
+  when:
+    - inventory_hostname in groups[item.group]
+    - item.enabled | default(true)
   with_items:
     - { name: ironic_pxe, group: ironic-pxe }
+    - { name: ironic_ipxe, group: ironic-ipxe, enabled: "{{ enable_ironic_ipxe | bool }}" }
     - { name: ironic_api, group: ironic-api }
     - { name: ironic_conductor, group: ironic-conductor }
     - { name: ironic_inspector, group: ironic-inspector }
@@ -53,10 +62,12 @@
   register: remove_containers
   when:
     - inventory_hostname in groups[item[0]['group']]
+    - item[0]['enabled'] | default(true)
     - config_strategy == "COPY_ONCE" or item[1]['KOLLA_CONFIG_STRATEGY'] == 'COPY_ONCE'
     - item[2]['rc'] == 1
   with_together:
     - [{ name: ironic_pxe, group: ironic-pxe },
+       { name: ironic_ipxe, group: ironic-ipxe, enabled: "{{ enable_ironic_ipxe | bool }}" },
        { name: ironic_api, group: ironic-api },
        { name: ironic_conductor, group: ironic-conductor },
        { name: ironic_inspector, group: ironic-inspector },
@@ -73,11 +84,13 @@
     action: "restart_container"
   when:
     - inventory_hostname in groups[item[0]['group']]
+    - item[0]['enabled'] | default(true)
     - config_strategy == 'COPY_ALWAYS'
     - item[1]['KOLLA_CONFIG_STRATEGY'] != 'COPY_ONCE'
     - item[2]['rc'] == 1
   with_together:
     - [{ name: ironic_pxe, group: ironic-pxe },
+       { name: ironic_ipxe, group: ironic-ipxe, enabled: "{{ enable_ironic_ipxe | bool }}" },
        { name: ironic_api, group: ironic-api },
        { name: ironic_conductor, group: ironic-conductor },
        { name: ironic_inspector, group: ironic-inspector },

--- a/ansible/roles/ironic/tasks/start.yml
+++ b/ansible/roles/ironic/tasks/start.yml
@@ -11,6 +11,21 @@
       - "ironic_pxe:/tftpboot/"
   when: inventory_hostname in groups['ironic-pxe']
 
+- name: Starting ironic-ipxe container
+  kolla_docker:
+    action: "start_container"
+    common_options: "{{ docker_common_options }}"
+    name: "ironic_ipxe"
+    image: "{{ ironic_pxe_image_full }}"
+    volumes:
+      - "{{ node_config_directory }}/ironic-ipxe/:{{ container_config_directory }}/:ro"
+      - "/etc/localtime:/etc/localtime:ro"
+      - "kolla_logs:/var/log/kolla"
+      - "ironic_ipxe:/httpboot/"
+  when:
+    - enable_ironic_ipxe | bool
+    - inventory_hostname in groups['ironic-ipxe']
+
 - name: Starting ironic-api container
   kolla_docker:
     action: "start_container"
@@ -40,6 +55,7 @@
       - "kolla_logs:/var/log/kolla"
       - "ironic:/var/lib/ironic"
       - "ironic_pxe:/tftpboot/"
+      - "ironic_ipxe:/httpboot/"
   when: inventory_hostname in groups['ironic-conductor']
 
 - name: Starting ironic-inspector container

--- a/ansible/roles/ironic/templates/inspector.ipxe.j2
+++ b/ansible/roles/ironic/templates/inspector.ipxe.j2
@@ -1,0 +1,10 @@
+#!ipxe
+
+:retry_dhcp
+dhcp || goto retry_dhcp
+
+:retry_boot
+imgfree
+kernel --timeout 30000 {{ ironic_ipxe_url }}/ironic-agent.kernel ipa-inspection-callback-url=http://{{ kolla_internal_vip_address }}:{{ ironic_inspector_port }}/v1/continue systemd.journald.forward_to_console=yes BOOTIF=${mac} initrd=agent.ramdisk || goto retry_boot
+initrd --timeout 30000 {{ ironic_ipxe_url }}/ironic-agent.initramfs || goto retry_boot
+boot

--- a/ansible/roles/ironic/templates/ironic-conductor.json.j2
+++ b/ansible/roles/ironic/templates/ironic-conductor.json.j2
@@ -29,6 +29,11 @@
             "path": "/tftpboot",
             "owner": "ironic:ironic",
             "recurse": true
+        },
+        {
+            "path": "/httpboot",
+            "owner": "ironic:ironic",
+            "recurse": true
         }
     ]
 }

--- a/ansible/roles/ironic/templates/ironic-dnsmasq.conf.j2
+++ b/ansible/roles/ironic/templates/ironic-dnsmasq.conf.j2
@@ -5,5 +5,22 @@ dhcp-option=option:tftp-server,{{ kolla_internal_vip_address }}
 dhcp-option=option:server-ip-address,{{ kolla_internal_vip_address }}
 bind-interfaces
 dhcp-sequential-ip
-dhcp-option=option:bootfile-name,pxelinux.0
 dhcp-option=210,/tftpboot/
+
+{% if enable_ironic_ipxe | bool %}
+
+dhcp-match=ipxe,175
+dhcp-match=set:efi,option:client-arch,7
+dhcp-match=set:efi,option:client-arch,9
+# Client is already running iPXE; move to next stage of chainloading
+dhcp-option=tag:ipxe,option:bootfile-name,{{ ironic_ipxe_url }}/inspector.ipxe
+# Client is PXE booting over EFI without iPXE ROM,
+# send EFI version of iPXE chainloader
+dhcp-option=tag:efi,tag:!ipxe,option:bootfile-name,ipxe.efi
+dhcp-option=option:bootfile-name,undionly.kpxe
+
+{% else %}
+
+dhcp-option=option:bootfile-name,pxelinux.0
+
+{% endif %}

--- a/ansible/roles/ironic/templates/ironic-ipxe-httpd.conf.j2
+++ b/ansible/roles/ironic/templates/ironic-ipxe-httpd.conf.j2
@@ -1,0 +1,16 @@
+Listen {{ api_interface_address }}:{{ ironic_ipxe_port }}
+
+TraceEnable off
+
+<VirtualHost *:{{ ironic_ipxe_port }}>
+    LogLevel warn
+    ErrorLog "/var/log/kolla/ironic/ironic-ipxe-error.log"
+    LogFormat "%h %l %u %t \"%r\" %>s %b %D \"%{Referer}i\" \"%{User-Agent}i\"" logformat
+    CustomLog "/var/log/kolla/ironic/ironic-ipxe-access.log" logformat
+    DocumentRoot "/httpboot"
+    <Directory /httpboot>
+        Options FollowSymLinks
+        AllowOverride None
+        Require all granted
+    </Directory>
+</VirtualHost>

--- a/ansible/roles/ironic/templates/ironic-ipxe.json.j2
+++ b/ansible/roles/ironic/templates/ironic-ipxe.json.j2
@@ -1,0 +1,33 @@
+{% set apache_conf_dir = 'apache2/conf-enabled' if kolla_base_distro in ['ubuntu', 'debian'] else 'httpd/conf.d' %}
+{% set apache_cmd = 'apache2' if kolla_base_distro in ['ubuntu', 'debian'] else 'httpd' %}
+{
+    "command": "{{ apache_cmd }} -DFOREGROUND",
+    "config_files": [
+{% if groups['ironic-inspector'] | length > 0 %}
+        {
+            "source": "{{ container_config_directory }}/ironic-agent.kernel",
+            "dest": "/httpboot/ironic-agent.kernel",
+            "owner": "root",
+            "perm": "0644"
+        },
+        {
+            "source": "{{ container_config_directory }}/ironic-agent.initramfs",
+            "dest": "/httpboot/ironic-agent.initramfs",
+            "owner": "root",
+            "perm": "0644"
+        },
+        {
+            "source": "{{ container_config_directory }}/inspector.ipxe",
+            "dest": "/httpboot/inspector.ipxe",
+            "owner": "root",
+            "perm": "0644"
+        },
+{% endif %}
+        {
+            "source": "{{ container_config_directory }}/httpd.conf",
+            "dest": "/etc/{{ apache_conf_dir }}/httpboot.conf",
+            "owner": "root",
+            "perm": "0644"
+        }
+    ]
+}

--- a/ansible/roles/ironic/templates/ironic-pxe.json.j2
+++ b/ansible/roles/ironic/templates/ironic-pxe.json.j2
@@ -4,7 +4,7 @@
 {
     "command": "/usr/sbin/in.tftpd --verbose --foreground --user root --address 0.0.0.0:69 --map-file /map-file /tftpboot",
     "config_files": [
-{% if groups['ironic-inspector'] | length > 0 %}
+{% if not enable_ironic_ipxe | bool and groups['ironic-inspector'] | length > 0%}
 {% if not enable_ironic_pxe_uefi | bool %}
         {
             "source": "{{ container_config_directory }}/ironic-agent.kernel",

--- a/ansible/roles/ironic/templates/ironic.conf.j2
+++ b/ansible/roles/ironic/templates/ironic.conf.j2
@@ -97,3 +97,17 @@ deploy_logs_collect = always
 
 [pxe]
 pxe_append_params = nofb nomodeset vga=normal console=tty0 console=ttyS0,{{ ironic_console_serial_speed }}
+{% if enable_ironic_ipxe | bool %}
+ipxe_enabled = True
+pxe_bootfile_name = undionly.kpxe
+uefi_pxe_bootfile_name = ipxe.efi
+pxe_config_template = $pybasedir/drivers/modules/ipxe_config.template
+uefi_pxe_config_template = $pybasedir/drivers/modules/ipxe_config.template
+tftp_root = /httpboot
+tftp_master_path = /httpboot/master_images
+{% endif %}
+
+{% if enable_ironic_ipxe | bool %}
+[deploy]
+http_url = {{ ironic_ipxe_url }}
+{% endif %}

--- a/doc/source/reference/ironic-guide.rst
+++ b/doc/source/reference/ironic-guide.rst
@@ -52,6 +52,27 @@ Set ironic_console_serial_speed in ``/etc/kolla/globals.yml``:
 
 .. _web_console_documentation: https://docs.openstack.org/ironic/latest/admin/console.html#node-web-console
 
+Booting with iPXE
+=================
+To enable iPXE support, set enable_ironic_ipxe in ``/etc/kolla/globals.yml``:
+
+::
+
+    enable_ironic_ipxe: "yes"
+
+This will enable deployment of a docker container called ironic_ipxe, running
+the web server which iPXE uses to obtain it's boot images.
+
+The port used for the iPXE webserver is controlled via ironic_ipxe_port in
+``/etc/kolla/globals.yml``:
+
+::
+
+    ironic_ipxe_port: "8089"
+
+Ironic will configure the DHCP settings to enable chainloading iPXE from an
+existing PXE environment.
+
 Post-deployment configuration
 =============================
 Configuration based off upstream documentation_.


### PR DESCRIPTION
Add support for enabling ipxe boot with ironic

When enable_ironic_ipxe is set in /etc/kolla/globals.yml,
the following happens:

- a new docker container, ironic_ipxe, is created. This contains
  an apache webserver used to serve up the boot images
- ironic is configured to use ipxe

Implements: blueprint ironic-ipxe
(cherry picked from commit 803dd85f2204222281401b70a3a62bf3dd68411e)

Change-Id: I13c002594b52625c1c99a65745ba6f587f509097