### PR TITLE
Support Ironic Inspector dnsmasq PXE filter

### DIFF
--- a/ansible/roles/ironic/defaults/main.yml
+++ b/ansible/roles/ironic/defaults/main.yml
@@ -69,3 +69,4 @@ ironic_dnsmasq_dhcp_range:
 ironic_cleaning_network:
 ironic_console_serial_speed: "115200n8"
 ironic_ipxe_url: http://{{ api_interface_address }}:{{ ironic_ipxe_port }}
+ironic_inspector_pxe_filter: iptables

--- a/ansible/roles/ironic/tasks/start.yml
+++ b/ansible/roles/ironic/tasks/start.yml
@@ -69,6 +69,7 @@
       - "{{ node_config_directory }}/ironic-inspector/:{{ container_config_directory }}/:ro"
       - "/etc/localtime:/etc/localtime:ro"
       - "kolla_logs:/var/log/kolla"
+      - "ironic_inspector_dhcp_hosts:/var/lib/ironic-inspector/dhcp-hostsdir"
   when: inventory_hostname in groups['ironic-inspector']
 
 - name: Starting ironic-dnsmasq container
@@ -80,4 +81,5 @@
     volumes:
       - "{{ node_config_directory }}/ironic-dnsmasq/:{{ container_config_directory }}/:ro"
       - "/etc/localtime:/etc/localtime:ro"
+      - "ironic_inspector_dhcp_hosts:/etc/dnsmasq/dhcp-hostsdir:ro"
   when: inventory_hostname in groups['ironic-inspector']

--- a/ansible/roles/ironic/templates/ironic-dnsmasq.conf.j2
+++ b/ansible/roles/ironic/templates/ironic-dnsmasq.conf.j2
@@ -24,3 +24,7 @@ dhcp-option=option:bootfile-name,undionly.kpxe
 dhcp-option=option:bootfile-name,pxelinux.0
 
 {% endif %}
+
+{% if ironic_inspector_pxe_filter == 'dnsmasq' %}
+dhcp-hostsdir=/etc/dnsmasq/dhcp-hostsdir
+{% endif %}

--- a/ansible/roles/ironic/templates/ironic-inspector.conf.j2
+++ b/ansible/roles/ironic/templates/ironic-inspector.conf.j2
@@ -34,8 +34,13 @@ memcached_servers = {% for host in groups['memcached'] %}{{ hostvars[host]['ansi
 policy_file = {{ ironic_policy_file }}
 {% endif %}
 
-[firewall]
-dnsmasq_interface = {{ ironic_dnsmasq_interface }}
-
 [database]
 connection = mysql+pymysql://{{ ironic_inspector_database_user }}:{{ ironic_inspector_database_password }}@{{ ironic_inspector_database_address }}/{{ ironic_inspector_database_name }}
+
+[pxe_filter]
+driver = {{ ironic_inspector_pxe_filter }}
+
+{% if ironic_inspector_pxe_filter == 'iptables' %}
+[iptables]
+dnsmasq_interface = {{ ironic_dnsmasq_interface }}
+{% endif %}


### PR DESCRIPTION
The dnsmasq PXE filter [1] provides far better scalability than the
iptables filter typically used. Inspector manages files in a dhcp-hostsdir
directory that is watched by dnsmasq via inotify. Dnsmasq then either
whitelists or blacklists MAC addresses based on the contents of these
files.

[1]
https://docs.openstack.org/ironic-inspector/latest/admin/dnsmasq-pxe-filter.html

Change-Id: I73cae9c33b49972342cf1984372a5c784df5cbc2