### PR TITLE
Generate Ceph configuration during upgrade

### DIFF
--- a/ansible/roles/cinder/tasks/ceph.yml
+++ b/ansible/roles/cinder/tasks/ceph.yml
@@ -1,18 +1,4 @@
 ---
-- name: Ensuring config directory exists
-  vars:
-    services_need_directory:
-      - "cinder-volume"
-      - "cinder-backup"
-  file:
-    path: "{{ node_config_directory }}/{{ item.key }}"
-    state: "directory"
-  when:
-    - item.value.enabled | bool
-    - inventory_hostname in groups[item.value.group]
-    - item.key in services_need_directory
-  with_dict: "{{ cinder_services }}"
-
 - name: Copying over ceph.conf(s)
   vars:
     services_need_config:

--- a/ansible/roles/cinder/tasks/config.yml
+++ b/ansible/roles/cinder/tasks/config.yml
@@ -9,6 +9,21 @@
     - item.value.enabled | bool
   with_dict: "{{ cinder_services }}"
 
+- include: ceph.yml
+  when:
+    - (enable_ceph | bool) and (cinder_backend_ceph | bool)
+    - inventory_hostname in groups['ceph-mon'] or
+        inventory_hostname in groups['cinder-api'] or
+        inventory_hostname in groups['cinder-volume'] or
+        inventory_hostname in groups['cinder-scheduler'] or
+        inventory_hostname in groups['cinder-backup']
+
+- include: external_ceph.yml
+  when:
+    - (enable_ceph | bool == False) and (cinder_backend_ceph | bool)
+    - inventory_hostname in groups['cinder-volume'] or
+      inventory_hostname in groups['cinder-backup']
+
 - name: Check if policies shall be overwritten
   local_action: stat path="{{ item }}"
   run_once: True

--- a/ansible/roles/cinder/tasks/deploy.yml
+++ b/ansible/roles/cinder/tasks/deploy.yml
@@ -1,24 +1,10 @@
 ---
-- include: ceph.yml
-  when:
-    - (enable_ceph | bool) and (cinder_backend_ceph | bool)
-    - inventory_hostname in groups['ceph-mon'] or
-        inventory_hostname in groups['cinder-api'] or
-        inventory_hostname in groups['cinder-volume'] or
-        inventory_hostname in groups['cinder-scheduler'] or
-        inventory_hostname in groups['cinder-backup']
-
-- include: external_ceph.yml
-  when:
-    - (enable_ceph | bool == False) and (cinder_backend_ceph | bool)
-    - inventory_hostname in groups['cinder-volume'] or
-      inventory_hostname in groups['cinder-backup']
-
 - include: register.yml
   when: inventory_hostname in groups['cinder-api']
 
 - include: config.yml
-  when: inventory_hostname in groups['cinder-api'] or
+  when: inventory_hostname in groups['ceph-mon'] or
+        inventory_hostname in groups['cinder-api'] or
         inventory_hostname in groups['cinder-volume'] or
         inventory_hostname in groups['cinder-scheduler'] or
         inventory_hostname in groups['cinder-backup']

--- a/ansible/roles/cinder/tasks/external_ceph.yml
+++ b/ansible/roles/cinder/tasks/external_ceph.yml
@@ -1,18 +1,4 @@
 ---
-- name: Ensuring config directory exists
-  vars:
-    services_need_directory:
-      - "cinder-volume"
-      - "cinder-backup"
-  file:
-    path: "{{ node_config_directory }}/{{ item.key }}"
-    state: "directory"
-  when:
-    - item.value.enabled | bool
-    - inventory_hostname in groups[item.value.group]
-    - item.key in services_need_directory
-  with_dict: "{{ cinder_services }}"
-
 - name: Copying over ceph.conf for Cinder
   vars:
     services_need_config:

--- a/ansible/roles/glance/tasks/ceph.yml
+++ b/ansible/roles/glance/tasks/ceph.yml
@@ -1,11 +1,4 @@
 ---
-- name: Ensuring config directory exists
-  file:
-    path: "{{ node_config_directory }}/glance-api"
-    state: "directory"
-    mode: "0770"
-  when: inventory_hostname in groups['glance-api']
-
 - name: Copying over ceph.conf(s)
   merge_configs:
     sources:

--- a/ansible/roles/glance/tasks/config.yml
+++ b/ansible/roles/glance/tasks/config.yml
@@ -1,14 +1,4 @@
 ---
-- include: ceph.yml
-  when:
-    - enable_ceph | bool
-    - glance_backend_ceph | bool
-
-- include: external_ceph.yml
-  when:
-    - enable_ceph | bool == False
-    - glance_backend_ceph | bool
-
 - name: Ensuring config directories exist
   file:
     path: "{{ node_config_directory }}/{{ item.key }}"
@@ -21,6 +11,16 @@
     - inventory_hostname in groups[item.value.group]
     - item.value.enabled | bool
   with_dict: "{{ glance_services }}"
+
+- include: ceph.yml
+  when:
+    - enable_ceph | bool
+    - glance_backend_ceph | bool
+
+- include: external_ceph.yml
+  when:
+    - enable_ceph | bool == False
+    - glance_backend_ceph | bool
 
 - name: Check if policies shall be overwritten
   local_action: stat path="{{ item }}"

--- a/ansible/roles/glance/tasks/external_ceph.yml
+++ b/ansible/roles/glance/tasks/external_ceph.yml
@@ -1,11 +1,4 @@
 ---
-- name: Ensuring config directory exists
-  file:
-    path: "{{ node_config_directory }}/glance-api"
-    state: "directory"
-    mode: "0770"
-  when: inventory_hostname in groups['glance-api']
-
 - name: Copy over ceph files
   copy:
     src: "{{ item }}"

--- a/ansible/roles/gnocchi/tasks/ceph.yml
+++ b/ansible/roles/gnocchi/tasks/ceph.yml
@@ -1,14 +1,4 @@
 ---
-- name: Ensuring config directory exists
-  file:
-    path: "{{ node_config_directory }}/{{ item }}"
-    state: "directory"
-  when: inventory_hostname in groups[item]
-  with_items:
-    - "gnocchi-api"
-    - "gnocchi-metricd"
-    - "gnocchi-statsd"
-
 - name: Copying over ceph.conf(s)
   merge_configs:
     sources:

--- a/ansible/roles/gnocchi/tasks/config.yml
+++ b/ansible/roles/gnocchi/tasks/config.yml
@@ -9,6 +9,16 @@
     - item.value.enabled | bool
   with_dict: "{{ gnocchi_services }}"
 
+- include: ceph.yml
+  when:
+    - enable_ceph | bool
+    - gnocchi_backend_storage == 'ceph'
+
+- include: external_ceph.yml
+  when:
+    - enable_ceph | bool == False
+    - gnocchi_backend_storage == 'ceph'
+
 - name: Check if policies shall be overwritten
   local_action: stat path="{{ item }}"
   run_once: True

--- a/ansible/roles/gnocchi/tasks/deploy.yml
+++ b/ansible/roles/gnocchi/tasks/deploy.yml
@@ -1,14 +1,4 @@
 ---
-- include: ceph.yml
-  when:
-    - enable_ceph | bool
-    - gnocchi_backend_storage == 'ceph'
-
-- include: external_ceph.yml
-  when:
-    - enable_ceph | bool == False
-    - gnocchi_backend_storage == 'ceph'
-
 - include: register.yml
   when: inventory_hostname in groups['gnocchi-api']
 

--- a/ansible/roles/gnocchi/tasks/external_ceph.yml
+++ b/ansible/roles/gnocchi/tasks/external_ceph.yml
@@ -1,14 +1,4 @@
 ---
-- name: Ensuring config directory exists
-  file:
-    path: "{{ node_config_directory }}/{{ item }}"
-    state: "directory"
-  when: inventory_hostname in groups[item]
-  with_items:
-    - "gnocchi-api"
-    - "gnocchi-metricd"
-    - "gnocchi-statsd"
-
 - name: Copy over ceph.conf file
   copy:
     src: "{{ node_custom_config }}/{{ item }}/ceph.conf"

--- a/ansible/roles/manila/tasks/ceph.yml
+++ b/ansible/roles/manila/tasks/ceph.yml
@@ -1,9 +1,4 @@
 ---
-- name: Ensuring config directory exists
-  file:
-    path: "{{ node_config_directory }}/manila-share"
-    state: "directory"
-
 - name: Copying over ceph.conf for manila
   merge_configs:
     sources:

--- a/ansible/roles/manila/tasks/config.yml
+++ b/ansible/roles/manila/tasks/config.yml
@@ -9,6 +9,20 @@
     - item.value.enabled | bool
   with_dict: "{{ manila_services }}"
 
+- include: ceph.yml
+  when:
+    - enable_ceph | bool
+    - enable_ceph_mds | bool
+    - (enable_manila_backend_cephfs_native | bool) or (enable_manila_backend_cephfs_nfs | bool)
+    - inventory_hostname in groups['manila-share']
+
+- include: external_ceph.yml
+  when:
+    - enable_ceph| bool == False
+    - enable_ceph_mds| bool == False
+    - (enable_manila_backend_cephfs_native | bool) or (enable_manila_backend_cephfs_nfs | bool)
+    - inventory_hostname in groups['manila-share']
+
 - name: Check if policies shall be overwritten
   local_action: stat path="{{ item }}"
   run_once: True

--- a/ansible/roles/manila/tasks/deploy.yml
+++ b/ansible/roles/manila/tasks/deploy.yml
@@ -1,19 +1,4 @@
 ---
-- include: ceph.yml
-  when:
-    - enable_ceph | bool
-    - enable_ceph_mds | bool
-    - (enable_manila_backend_cephfs_native | bool) or (enable_manila_backend_cephfs_nfs | bool)
-    - inventory_hostname in groups['manila-share']
-
-- include: external_ceph.yml
-  when:
-    - enable_ceph| bool == False
-    - enable_ceph_mds| bool == False
-    - (enable_manila_backend_cephfs_native | bool) or (enable_manila_backend_cephfs_nfs | bool)
-    - inventory_hostname in groups['manila-share']
-
-
 - include: register.yml
   when: inventory_hostname in groups['manila-api']
 

--- a/ansible/roles/manila/tasks/external_ceph.yml
+++ b/ansible/roles/manila/tasks/external_ceph.yml
@@ -1,11 +1,4 @@
 ---
-- name: Ensuring config directory exists
-  file:
-    path: "{{ node_config_directory }}/manila-share"
-    state: "directory"
-  when:
-    - inventory_hostname in groups['manila-share']
-
 - name: Copying over ceph.conf for manila
   merge_configs:
     sources:

--- a/ansible/roles/nova/tasks/ceph.yml
+++ b/ansible/roles/nova/tasks/ceph.yml
@@ -5,7 +5,6 @@
     state: "directory"
     mode: "0770"
   with_items:
-    - "nova-compute"
     - "nova-libvirt/secrets"
   when: inventory_hostname in groups['compute']
 

--- a/ansible/roles/nova/tasks/config.yml
+++ b/ansible/roles/nova/tasks/config.yml
@@ -24,6 +24,22 @@
     - item.value.enabled | bool
   with_dict: "{{ nova_services }}"
 
+- include: ceph.yml
+  when:
+    - enable_ceph | bool and nova_backend == "rbd"
+    - inventory_hostname in groups['ceph-mon'] or
+        inventory_hostname in groups['compute'] or
+        inventory_hostname in groups['nova-api'] or
+        inventory_hostname in groups['nova-conductor'] or
+        inventory_hostname in groups['nova-consoleauth'] or
+        inventory_hostname in groups['nova-novncproxy'] or
+        inventory_hostname in groups['nova-scheduler']
+
+- include: external_ceph.yml
+  when:
+    - not enable_ceph | bool and (nova_backend == "rbd" or cinder_backend_ceph | bool)
+    - inventory_hostname in groups['compute']
+
 - name: Check if policies shall be overwritten
   local_action: stat path="{{ item }}"
   run_once: True

--- a/ansible/roles/nova/tasks/deploy.yml
+++ b/ansible/roles/nova/tasks/deploy.yml
@@ -1,20 +1,4 @@
 ---
-- include: ceph.yml
-  when:
-    - enable_ceph | bool and nova_backend == "rbd"
-    - inventory_hostname in groups['ceph-mon'] or
-        inventory_hostname in groups['compute'] or
-        inventory_hostname in groups['nova-api'] or
-        inventory_hostname in groups['nova-conductor'] or
-        inventory_hostname in groups['nova-consoleauth'] or
-        inventory_hostname in groups['nova-novncproxy'] or
-        inventory_hostname in groups['nova-scheduler']
-
-- include: external_ceph.yml
-  when:
-    - not enable_ceph | bool and (nova_backend == "rbd" or cinder_backend_ceph | bool)
-    - inventory_hostname in groups['compute']
-
 - include: register.yml
   when: inventory_hostname in groups['nova-api']
 

--- a/ansible/roles/nova/tasks/external_ceph.yml
+++ b/ansible/roles/nova/tasks/external_ceph.yml
@@ -5,7 +5,6 @@
     state: "directory"
     mode: "0770"
   with_items:
-    - "nova-compute"
     - "nova-libvirt/secrets"
   when: inventory_hostname in groups['compute']
 


### PR DESCRIPTION
If upgrading the nova, cinder or manila services via 'kolla-ansible
upgrade', the Ceph config files are not generated. Users will expect
that these files are generated, to pull in any changes from their
configuration or the base kolla configuration.

This change moves Ceph tasks inside config.yml to ensure that they are
performed during deploy, reconfigure and upgrade. This has been done for
nova, cinder, gnocchi and manila - glance already does this.

Change-Id: Ic75692c2bcba9b81dee922ff6fbbccd160e7fa19
Closes-Bug: #1794275
(cherry picked from commit 9a793ad8a57ab8869040ede48a0445c2d989a3ac)