### PR TITLE
Support custom monasca-notification templates

### DIFF
--- a/ansible/roles/monasca/handlers/main.yml
+++ b/ansible/roles/monasca/handlers/main.yml
@@ -141,6 +141,7 @@
     - service.enabled | bool
     - config_json.changed | bool
       or monasca_notification_confs.changed | bool
+      or monasca_notification_plugin_templates.changed | bool
       or monasca_notification_container.changed | bool
 
 - name: Restart monasca-persister container

--- a/ansible/roles/monasca/tasks/config.yml
+++ b/ansible/roles/monasca/tasks/config.yml
@@ -236,6 +236,27 @@
   notify:
     - Restart monasca-notification container
 
+- name: Check for monasca-notification templates
+  local_action: stat path="{{ node_custom_config }}/monasca/notification_templates"
+  run_once: True
+  register: notification_templates
+
+- name: Copying over monasca-notification templates
+  vars:
+    service: "{{ monasca_services['monasca-notification'] }}"
+  copy:
+    src: "{{ node_custom_config }}/monasca/notification_templates"
+    dest: "{{ node_config_directory }}/monasca-notification/"
+    mode: "0660"
+  become: true
+  register: monasca_notification_plugin_templates
+  when:
+    - notification_templates.stat.exists and notification_templates.stat.isdir
+    - inventory_hostname in groups[service['group']]
+    - service.enabled | bool
+  notify:
+    - Restart monasca-notification container
+
 - name: Copying over monasca-persister config
   vars:
     service: "{{ monasca_services['monasca-persister'] }}"

--- a/ansible/roles/monasca/templates/monasca-notification/monasca-notification.json.j2
+++ b/ansible/roles/monasca/templates/monasca-notification/monasca-notification.json.j2
@@ -6,6 +6,12 @@
             "dest": "/etc/monasca/notification.conf",
             "owner": "monasca",
             "perm": "0600"
+        },
+        {
+            "source": "{{ container_config_directory }}/notification_templates/*",
+            "dest": "/etc/monasca/",
+            "owner": "monasca",
+            "perm": "0600"
         }
     ],
     "permissions": [


### PR DESCRIPTION
Jira, Slack and possiblly other plugins allow custom templates
for defining the format of notifications. This change lets you
provide these in a templates folder which is copied into the
monasca-notification container.

Partially-Implements: blueprint monasca-roles
Change-Id: Ibc5ba3944d51f6c8ffc8bdc9ed60f43dd91ca7e0