### PR TITLE
Make tunnel timeout for nova_serialconsole_proxy configurable

### DIFF
--- a/ansible/roles/haproxy/defaults/main.yml
+++ b/ansible/roles/haproxy/defaults/main.yml
@@ -42,6 +42,8 @@ haproxy_server_timeout: "1m"
 haproxy_glance_api_client_timeout: "6h"
 haproxy_glance_api_server_timeout: "6h"
 
+haproxy_nova_serialconsole_proxy_tunnel_timeout: "10m"
+
 syslog_server: "{{ api_interface_address }}"
 syslog_haproxy_facility: "local1"
 

--- a/ansible/roles/haproxy/templates/haproxy.cfg.j2
+++ b/ansible/roles/haproxy/templates/haproxy.cfg.j2
@@ -224,6 +224,7 @@ listen nova_rdp
 {% if enable_nova_serialconsole_proxy | bool %}
 listen nova_serialconsole_proxy
   bind {{ kolla_internal_vip_address }}:{{ nova_serialproxy_port }}
+  timeout tunnel {{ haproxy_nova_serialconsole_proxy_tunnel_timeout }}
 {% for host in groups['nova-serialproxy'] %}
   server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['ansible_' + hostvars[host]['api_interface']]['ipv4']['address'] }}:{{ nova_serialproxy_port }} check inter 2000 rise 2 fall 5
 {% endfor %}
@@ -275,6 +276,7 @@ listen nova_spicehtml5proxy_external
 {% if enable_nova_serialconsole_proxy | bool %}
 listen nova_serialconsole_proxy_external
   bind {{ kolla_external_vip_address }}:{{ nova_serialproxy_port }} {{ tls_bind_info }}
+  timeout tunnel {{ haproxy_nova_serialconsole_proxy_tunnel_timeout }}
   http-request del-header X-Forwarded-Proto
   http-request set-header X-Forwarded-Proto https if { ssl_fc }
 {% for host in groups['nova-serialproxy'] %}

--- a/releasenotes/notes/add-option-to-configure-nova-serial-console-timeout-7cfc764a0c19eb01.yaml
+++ b/releasenotes/notes/add-option-to-configure-nova-serial-console-timeout-7cfc764a0c19eb01.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Added an option, haproxy_nova_serialconsole_proxy_tunnel_timeout,
+    to configure the nova_serialconsole_proxy tunnel timeout. This default
+    is to keep the websocket connection alive for 10 minutes.


### PR DESCRIPTION
This is a backport of: https://review.openstack.org/#/c/614221/

Currently, the serial consoles as accessed through Horizon,
timeout after the haproxy_client_timeout (default: 1m) of
inactivity. This change allows you to set a larger timeout.

Change-Id: I2a9923cb69d5db976395146685aded83922c4120
Closes-Bug: #1800643