### PR TITLE
Set ramdisk logs path for ironic inspector

### DIFF
--- a/ansible/roles/ironic/templates/ironic-inspector.conf.j2
+++ b/ansible/roles/ironic/templates/ironic-inspector.conf.j2
@@ -37,6 +37,9 @@ policy_file = {{ ironic_policy_file }}
 [database]
 connection = mysql+pymysql://{{ ironic_inspector_database_user }}:{{ ironic_inspector_database_password }}@{{ ironic_inspector_database_address }}/{{ ironic_inspector_database_name }}
 
+[processing]
+ramdisk_logs_dir = /var/log/kolla/ironic-inspector
+
 [pxe_filter]
 driver = {{ ironic_inspector_pxe_filter }}
 

--- a/releasenotes/notes/inspector-ramdisk-logs-9623a734c4d56410.yaml
+++ b/releasenotes/notes/inspector-ramdisk-logs-9623a734c4d56410.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    The Bare Metal Inspection service is now configured to store logs from the
+    inspection ramdisk in the ``kolla_logs`` Docker volume.


### PR DESCRIPTION
If the [processing] ramdisk_logs_dir option is set, logs returned by the
ironic inspection ramdisk following hardware inspection will be stored
at that location. This enables easier debugging if inspection fails.

Change-Id: I36bdf75c04b088b67b5f54fdf20251c10bdddb63
(cherry picked from commit 7ebf548ff33ae5983121d9a1a3451d2fb8a4b2a8)