### PR TITLE
Explicitly specify endpoint type during Monasca registration

### DIFF
--- a/ansible/roles/monasca/tasks/register.yml
+++ b/ansible/roles/monasca/tasks/register.yml
@@ -11,6 +11,7 @@
       interface: "{{ item.interface }}"
       region_name: "{{ openstack_region_name }}"
       auth: "{{ monasca_openstack_auth }}"
+      endpoint_type: "{{ openstack_interface }}"
   run_once: True
   with_items:
     - {'interface': 'admin', 'url': '{{ monasca_api_admin_endpoint }}'}
@@ -29,6 +30,7 @@
       interface: "{{ item.interface }}"
       region_name: "{{ openstack_region_name }}"
       auth: "{{ monasca_openstack_auth }}"
+      endpoint_type: "{{ openstack_interface }}"
   run_once: True
   with_items:
     - {'interface': 'admin', 'url': '{{ monasca_log_api_admin_endpoint }}'}
@@ -45,6 +47,7 @@
       role: "admin"
       region_name: "{{ openstack_region_name }}"
       auth: "{{ monasca_openstack_auth }}"
+      endpoint_type: "{{ openstack_interface }}"
   run_once: True
 
 - name: Creating monasca roles
@@ -54,6 +57,7 @@
       name: "{{ item }}"
       region_name: "{{ openstack_region_name }}"
       auth: "{{ monasca_openstack_auth }}"
+      endpoint_type: "{{ openstack_interface }}"
   run_once: True
   with_items:
     - "{{ monasca_default_authorized_roles }}"


### PR DESCRIPTION
Monasca defaults to using the public endpoint to register
Monasca endpoints which is bad practice and doesn't work on
some deployments. This change uses the admin interface by
default.

Change-Id: Ia9c5e041e71867fe72aad43e1344cd2107652d7d
Co-Authored-By: Mark Goddard <mark@stackhpc.com>
Closes-Bug: #1787610