### PR TITLE
Fix elasticsearch server list in Monasca Log API

### DIFF
--- a/ansible/roles/monasca/templates/monasca-log-api/log-api.conf.j2
+++ b/ansible/roles/monasca/templates/monasca-log-api/log-api.conf.j2
@@ -42,4 +42,4 @@ memcache_secret_key = {{ memcache_secret_key }}
 memcached_servers = {{ monasca_memcached_servers }}
 
 [elasticsearch]
-uris = {{ monasca_elasticsearch_servers }}
+uris = {{ monasca_elasticsearch_servers | replace("'", "") }}


### PR DESCRIPTION
The Log API can't parse a string like 'foo','bar'. This change
removes the single quotes so that it can correctly parse the
list of servers.

Change-Id: I4c1b8d33371dcc92cb0ad639adbd80779a8639d5