### PR TITLE
openvswitch: always run handler to to ensure OVS bridges are up

### DIFF
--- a/ansible/roles/openvswitch/handlers/main.yml
+++ b/ansible/roles/openvswitch/handlers/main.yml
@@ -21,7 +21,6 @@
 
   notify:
     - Waiting for openvswitch_db service to be ready
-    - Ensuring OVS bridge is properly setup
 
 - name: Waiting for openvswitch_db service to be ready
   command: docker exec openvswitch_db ovs-vsctl --no-wait show
@@ -31,17 +30,6 @@
   retries: 30
   delay: 2
   notify:
-
-- name: Ensuring OVS bridge is properly setup
-  command: docker exec openvswitch_db /usr/local/bin/kolla_ensure_openvswitch_configured {{ item.0 }} {{ item.1 }}
-  register: status
-  changed_when: status.stdout.find('changed') != -1
-  when:
-    - inventory_hostname in groups["network"]
-      or (inventory_hostname in groups["compute"] and computes_need_external_bridge | bool )
-  with_together:
-    - "{{ neutron_bridge_name.split(',') }}"
-    - "{{ neutron_external_interface.split(',') }}"
 
 - name: Restart openvswitch-vswitchd container
   vars:

--- a/ansible/roles/openvswitch/tasks/deploy.yml
+++ b/ansible/roles/openvswitch/tasks/deploy.yml
@@ -6,3 +6,5 @@
 
 - name: Flush Handlers
   meta: flush_handlers
+
+- include_tasks: ensure-ovs-bridge.yml

--- a/ansible/roles/openvswitch/tasks/ensure-ovs-bridge.yml
+++ b/ansible/roles/openvswitch/tasks/ensure-ovs-bridge.yml
@@ -1,0 +1,12 @@
+---
+- name: Ensuring OVS bridge is properly setup
+  command: docker exec openvswitch_db /usr/local/bin/kolla_ensure_openvswitch_configured {{ item.0 }} {{ item.1 }}
+  register: status
+  changed_when: status.stdout.find('changed') != -1
+  when:
+    - inventory_hostname in groups["network"]
+      or (inventory_hostname in groups["compute"] and computes_need_external_bridge | bool )
+    - not enable_onos | bool
+  with_together:
+    - "{{ neutron_bridge_name.split(',') }}"
+    - "{{ neutron_external_interface.split(',') }}"

--- a/ansible/roles/openvswitch/tasks/upgrade.yml
+++ b/ansible/roles/openvswitch/tasks/upgrade.yml
@@ -3,3 +3,5 @@
 
 - name: Flush Handlers
   meta: flush_handlers
+
+- include_tasks: ensure-ovs-bridge.yml


### PR DESCRIPTION
When editing external bridge configuration and running a reconfigure
on openvswitch, handler "Ensuring OVS bridge is properly setup"
needs to run, but doesn't.

This moves the task from handlers to own file and always includes it
after running the handlers.

Change-Id: Iee39cf00b743ab0776354749c6e162814b5584d8
Closes-Bug: #1794504

Conflicts:
	ansible/roles/openvswitch/handlers/main.yml