### PR TITLE
Fix broken cherry-pick

### DIFF
--- a/ansible/roles/openvswitch/tasks/ensure-ovs-bridge.yml
+++ b/ansible/roles/openvswitch/tasks/ensure-ovs-bridge.yml
@@ -6,7 +6,6 @@
   when:
     - inventory_hostname in groups["network"]
       or (inventory_hostname in groups["compute"] and computes_need_external_bridge | bool )
-    - not enable_onos | bool
   with_together:
     - "{{ neutron_bridge_name.split(',') }}"
     - "{{ neutron_external_interface.split(',') }}"


### PR DESCRIPTION
commit 10fe4cd69d78a463621db036b7d5a4bf555b872f references a variable,
`enable_onos`, that does not exist in the queens release:

```
TASK [openvswitch : Ensuring OVS bridge is properly setup] ***********************************************************
fatal: [kef1c-phyldb0001]: FAILED! => {"msg": "The conditional check 'not enable_onos | bool' failed. The error was: e
rror while evaluating conditional (not enable_onos | bool): 'enable_onos' is undefined\n\nThe error appears to have be
en in '/home/verne/kayobe-env/venvs/kolla-ansible/share/kolla-ansible/ansible/roles/openvswitch/tasks/ensure-ovs-bridg
e.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending li
ne appears to be:\n\n---\n- name: Ensuring OVS bridge is properly setup\n  ^ here\n"}
fatal: [kef1c-phyldb0002]: FAILED! => {"msg": "The conditional check 'not enable_onos | bool' failed. The error was: e
rror while evaluating conditional (not enable_onos | bool): 'enable_onos' is undefined\n\nThe error appears to have be
en in '/home/verne/kayobe-env/venvs/kolla-ansible/share/kolla-ansible/ansible/roles/openvswitch/tasks/ensure-ovs-bridg
e.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending li
ne appears to be:\n\n---\n- name: Ensuring OVS bridge is properly setup\n  ^ here\n"}
        to retry, use: --limit @/home/verne/kayobe-env/venvs/kolla-ansible/share/kolla-ansible/ansible/site.retry
```