### PR TITLE
Parse Monasca Log API timestamps correctly

### DIFF
--- a/ansible/roles/monasca/templates/monasca-log-transformer/log-transformer.conf.j2
+++ b/ansible/roles/monasca/templates/monasca-log-transformer/log-transformer.conf.j2
@@ -18,6 +18,14 @@ filter {
         remove_field => [ "[log][dimensions][timestamp]", "[log][dimensions][Timestamp]" ]
     }
 
+    # Monasca Log API adds a timestamp when it processes a log entry. This
+    # timestamp needs to be converted from seconds since the epoch for
+    # Elasticsearch to parse it correctly. Here we make that conversion.
+    date {
+        match => ["creation_time", "UNIX"]
+        target => "creation_time"
+    }
+
     # OpenStack log levels are uppercase, and syslog are lowercase.
     # Furthermore, syslog has more log levels that OpenStack. To avoid
     # mapping syslog log levels to OpenStack log levels, we standardise


### PR DESCRIPTION
By parsing the creation_time timestamp in Logstash, Elasticsearch
can parse it correctly. This closes a bug where the creation_time
timestamp was shown as a date shortly after the epoch (1970) when
viewed in Kibana.

Closes-Bug: #1816585

Change-Id: I00decfe94607845ef0eae9bec631a0e729aac3fa