### PR TITLE
Fix reconfigure of neutron ml2_conf.ini

### DIFF
--- a/ansible/roles/neutron/handlers/main.yml
+++ b/ansible/roles/neutron/handlers/main.yml
@@ -62,7 +62,7 @@
     service: "{{ neutron_services[service_name] }}"
     config_json: "{{ neutron_config_jsons.results|selectattr('item.key', 'equalto', service_name)|first }}"
     neutron_conf: "{{ neutron_confs.results|selectattr('item.key', 'equalto', service_name)|first }}"
-    neutron_ml2_conf: "{{ neutron_ml2_confs.results|selectattr('item.key', 'equalto', service_name)|first }}"
+    neutron_ml2_xenapi_conf: "{{ neutron_ml2_xenapi_confs.results|selectattr('item.key', 'equalto', service_name)|first }}"
     policy_json: "{{ policy_jsons.results|selectattr('item.key', 'equalto', service_name)|first }}"
     neutron_openvswitch_agent_xenapi_container: "{{ check_neutron_containers.results|selectattr('item.key', 'equalto', service_name)|first }}"
   kolla_docker:
@@ -78,7 +78,7 @@
     - service.host_in_groups | bool
     - config_json | changed
       or neutron_conf | changed
-      or neutron_ml2_conf | changed
+      or neutron_ml2_xenapi_conf | changed
       or policy_json | changed
       or neutron_openvswitch_agent_xenapi_container | changed
 

--- a/ansible/roles/neutron/tasks/config.yml
+++ b/ansible/roles/neutron/tasks/config.yml
@@ -156,7 +156,7 @@
       - "{{ node_custom_config }}/neutron/{{ service_name }}/ml2_conf.ini"
     dest: "{{ node_config_directory }}/{{ service_name }}/ml2_conf.ini"
     mode: "0660"
-  register: neutron_ml2_confs
+  register: neutron_ml2_xenapi_confs
   when:
     - item.key in services_need_ml2_conf_ini
     - item.value.enabled | bool


### PR DESCRIPTION
The neutron containers were not being restarted if only the ml2_conf.ini
file is changed. This is due to the XenAPI ml2_conf.ini config task
registering a variable of the same name as the task that generates
ml2_conf.ini for other services. Since the XenAPI service is typically
not running, the tasks show as not changed, and the handler skips
restarting the container.

This change adds a second variable for XenAPI to avoid this shadowing.

Change-Id: I77819ed8defb8a7653e1e5aec92013b1d40fbf02
Closes-Bug: #1783268
(cherry picked from commit 43c83b51cfcee320fc52218925e88d0fe1b05100)