### PR TITLE
Add support for using custom Logstash patterns

### DIFF
--- a/ansible/roles/monasca/handlers/main.yml
+++ b/ansible/roles/monasca/handlers/main.yml
@@ -60,6 +60,7 @@
     - config_json.changed | bool
       or monasca_log_transformer_confs.changed | bool
       or monasca_log_transformer_container.changed | bool
+      or monasca_custom_logstash_patterns_configured.changed | bool
 
 - name: Restart monasca-log-persister container
   vars:

--- a/ansible/roles/monasca/tasks/config.yml
+++ b/ansible/roles/monasca/tasks/config.yml
@@ -144,6 +144,7 @@
     src: "{{ item.path }}"
     dest: "{{ node_config_directory }}/monasca-log-transformer/logstash_patterns/{{ item.path | basename }}"
     mode: "0660"
+  become: true
   register: monasca_custom_logstash_patterns_configured
   with_items: "{{ monasca_custom_logstash_patterns.files }}"
   when:

--- a/ansible/roles/monasca/tasks/config.yml
+++ b/ansible/roles/monasca/tasks/config.yml
@@ -117,6 +117,41 @@
   notify:
     - Restart monasca-log-transformer container
 
+- name: Ensuring logstash patterns folder exists
+  vars:
+    service: "{{ monasca_services['monasca-log-transformer'] }}"
+  file:
+    path: "{{ node_config_directory }}/monasca-log-transformer/logstash_patterns"
+    state: "directory"
+    mode: "0770"
+  become: true
+  when:
+    - inventory_hostname in groups[service['group']]
+    - service.enabled | bool
+
+- name: Find custom logstash patterns
+  local_action:
+    module: find
+    path: "{{ node_custom_config }}/monasca/logstash_patterns"
+    pattern: "*"
+  run_once: True
+  register: monasca_custom_logstash_patterns
+
+- name: Copying over custom logstash patterns
+  vars:
+    service: "{{ monasca_services['monasca-log-transformer'] }}"
+  template:
+    src: "{{ item.path }}"
+    dest: "{{ node_config_directory }}/monasca-log-transformer/logstash_patterns/{{ item.path | basename }}"
+    mode: "0660"
+  register: monasca_custom_logstash_patterns_configured
+  with_items: "{{ monasca_custom_logstash_patterns.files }}"
+  when:
+    - inventory_hostname in groups[service['group']]
+    - service.enabled | bool
+  notify:
+    - Restart monasca-log-transformer container
+
 - name: Copying over monasca-log-persister config
   vars:
     service: "{{ monasca_services['monasca-log-persister'] }}"

--- a/ansible/roles/monasca/templates/monasca-log-transformer/monasca-log-transformer.json.j2
+++ b/ansible/roles/monasca/templates/monasca-log-transformer/monasca-log-transformer.json.j2
@@ -6,6 +6,12 @@
             "dest": "/etc/logstash/conf.d/log-transformer.conf",
             "owner": "logstash",
             "perm": "0600"
+        },
+        {
+            "source": "{{ container_config_directory }}/logstash_patterns/*",
+            "dest": "/etc/logstash/conf.d/patterns/",
+            "owner": "logstash",
+            "perm": "0600"
         }
     ],
     "permissions": [


### PR DESCRIPTION
A user may want to define and use Logstash patterns. This
commit adds support to copy them into the Monasca Log
Transformer container. In the future support could be
added for other Logstash containers.

Change-Id: Id8cde14af6dc7f49714f6b1cb878882d0048d293