### PR TITLE
Fix issue finding Monasca collector plugins

### DIFF
--- a/ansible/roles/monasca/tasks/config.yml
+++ b/ansible/roles/monasca/tasks/config.yml
@@ -61,7 +61,8 @@
     - service.enabled | bool
 
 - name: Find monasca-agent-collector plugin configuration files
-  find:
+  local_action:
+    module: find
     paths:
       - "{{ role_path }}/templates/monasca-agent-collector/plugins/"
       - "{{ node_custom_config }}/monasca/agent_plugins/"

--- a/ansible/roles/monasca/tasks/post_config.yml
+++ b/ansible/roles/monasca/tasks/post_config.yml
@@ -21,6 +21,7 @@
     password: '{{ monasca_grafana_admin_password }}'
     return_content: true
     force_basic_auth: true
+  run_once: True
   register: monasca_grafana_orgs
 
 - name: Create default control plane organisation if it doesn't exist
@@ -33,6 +34,7 @@
     body:
       name: '{{ monasca_grafana_control_plane_org }}'
     force_basic_auth: true
+  run_once: True
   when: monasca_grafana_control_plane_org not in monasca_grafana_orgs.json|map(attribute='name')|unique
 
 - name: Lookup Monasca Grafana control plane organisation ID
@@ -43,6 +45,7 @@
     password: '{{ monasca_grafana_admin_password }}'
     return_content: true
     force_basic_auth: true
+  run_once: True
   register: monasca_grafana_conf_org
 
 - name: Add {{ monasca_grafana_admin_username }} user to control plane organisation
@@ -70,6 +73,7 @@
     user: '{{ monasca_grafana_admin_username }}'
     password: '{{ monasca_grafana_admin_password }}'
     force_basic_auth: true
+  run_once: True
 
 - name: Enable Monasca Grafana datasource for control plane organisation
   uri:


### PR DESCRIPTION
Plugins should be located *locally* and then distributed
to nodes running the Monasca Agent.