### PR TITLE
Set log message field name in Monasca Fluentd plugin

### DIFF
--- a/ansible/roles/common/templates/conf/filter/00-record_transformer.conf.j2
+++ b/ansible/roles/common/templates/conf/filter/00-record_transformer.conf.j2
@@ -37,20 +37,6 @@
 </filter>
 
 {% if enable_monasca | bool %}
-# Kolla Fluentd input config configures Fluentd to save all log messages
-# under the 'Payload' field, however the fluentd-monasca plugin assumes
-# that log messages are saved under the 'message' field. Here we map the
-# 'Payload' field to the 'message' field so that log can be forwarded to
-# Monasca.
-<filter *.**>
-  @type record_transformer
-  enable_ruby true
-  <record>
-    message ${record["Payload"]}
-  </record>
-  remove_keys Payload
-</filter>
-
 # Kolla configures Fluentd to extract timestamps from OpenStack service
 # logs, however these timestamps are not saved in the event and are not
 # forwarded to Monasca. Here we save the timestamp which has been

--- a/ansible/roles/common/templates/conf/output/00-local.conf.j2
+++ b/ansible/roles/common/templates/conf/output/00-local.conf.j2
@@ -27,6 +27,7 @@
        password {{ monasca_agent_password }}
        domain_id default
        project_name {{ monasca_control_plane_project }}
+       message_field_name Payload
     </store>
 {% endif %}
 </match>
@@ -62,6 +63,7 @@
        password {{ monasca_agent_password }}
        domain_id default
        project_name {{ monasca_control_plane_project }}
+       message_field_name Payload
     </store>
 {% endif %}
 </match>

--- a/ansible/roles/common/templates/conf/output/02-monasca.conf.j2
+++ b/ansible/roles/common/templates/conf/output/02-monasca.conf.j2
@@ -9,5 +9,6 @@
        password {{ monasca_agent_password }}
        domain_id default
        project_name {{ monasca_control_plane_project }}
+       message_field_name Payload
     </store>
 </match>


### PR DESCRIPTION
Let the Monasca Fluentd output plugin handle mapping of the log
message.

Change-Id: I4a74a91b9b38d5c172397a7e7204e626bcedcfac
Closes-Bug: #1830184
Depends-On: https://review.opendev.org/#/c/660988/
(cherry picked from commit 661f52ba2046a3ee48cfdf87e1e8b6198d24fe79)