### PR TITLE
Fix format file message field

### DIFF
--- a/ansible/roles/common/templates/conf/format/apache_access.conf.j2
+++ b/ansible/roles/common/templates/conf/format/apache_access.conf.j2
@@ -2,7 +2,7 @@
   @type parser
   reserve_data true
   format grok
-  key_name message
+  key_name Payload
   grok_pattern \[%{HTTPDATE:Timestamp}\] "(?:%{WORD:http_method} %{NOTSPACE:http_url}(?: HTTP/%{NUMBER:http_version})?|%{DATA:rawrequest})" %{NUMBER:http_status} (?:\d+|-)
   time_key Timestamp
   time_format %d/%b/%Y:%H:%M:%S %z

--- a/ansible/roles/common/templates/conf/format/wsgi_access.conf.j2
+++ b/ansible/roles/common/templates/conf/format/wsgi_access.conf.j2
@@ -2,7 +2,7 @@
   @type parser
   reserve_data true
   format grok
-  key_name message
+  key_name Payload
   grok_pattern %{IPORHOST:clientip} %{HTTPDUSER:ident} %{USER:auth} \[%{HTTPDATE:Timestamp}\] "(?:%{WORD:http_method} %{NOTSPACE:http_url}(?: HTTP/%{NUMBER:http_version})?|%{DATA:rawrequest})" %{NUMBER:http_status} (?:%{NUMBER:http_bytes}|-) (?:%{NUMBER:http_response_time_us}|-) %{QS:referrer} %{QS:agent}
   time_key Timestamp
   time_format %d/%b/%Y:%H:%M:%S %z

--- a/ansible/roles/common/templates/conf/format/wsgi_python.conf.j2
+++ b/ansible/roles/common/templates/conf/format/wsgi_python.conf.j2
@@ -2,7 +2,7 @@
   @type parser
   reserve_data true
   format grok
-  key_name message
+  key_name Payload
   grok_pattern %{TIMESTAMP_ISO8601:Timestamp} %{NUMBER:Pid} %{LOGLEVEL:log_level} %{NOTSPACE:python_module} \[(?:req-(?:%{NOTSPACE:request_id}) (?:%{NOTSPACE:user_id}) (?:%{NOTSPACE:tenant_id}) (?:%{NOTSPACE:domain_id}) (?:%{NOTSPACE:user_domain}) (?:%{NOTSPACE:project_domain})|-)\] %{GREEDYDATA:Payload}
   time_format "%Y-%m-%d %H:%M:%S.%L"
   time_key Timestamp


### PR DESCRIPTION
The message field for these format files wasn't renamed when
the input field was renamed. This problem was masked by Monasca
which renames the message field back to 'message' for the Fluentd
Monasca output plugin.

Change-Id: I2674958b1e64efddbca4765fefa55431261648e6
Closes-Bug: #1819168
(cherry picked from commit e5d564136b479e83da71ad08d31783a3f793314d)