### PR TITLE
Fix monasca grafana organisation check

### DIFF
--- a/ansible/roles/monasca/tasks/post_config.yml
+++ b/ansible/roles/monasca/tasks/post_config.yml
@@ -11,7 +11,7 @@
 
 - name: Define Monasca Grafana control plane organisation name
   set_fact:
-    monasca_grafana_control_plane_org: "{{ monasca_control_plane_project }}@{{ default_project_domain_name }}"
+    monasca_grafana_control_plane_org: "{{ monasca_control_plane_project }}@{{ default_project_domain_id }}"
 
 - name: List Monasca Grafana organisations
   uri:


### PR DESCRIPTION
"Create default control plane organisation if it doesn't exist" task
fails when organisation already exists.
The list organisation task currently returns project domain id.
The create organisation task currently provides project domain name.
Change the create task to use default_project_domain_id instead.

TrivialFix

Change-Id: Ice70d55e6729fe55164dcf85e98acdc1d7925209