### PR TITLE
Fix issue finding custom, host specific plugins

### DIFF
--- a/ansible/roles/monasca/tasks/config.yml
+++ b/ansible/roles/monasca/tasks/config.yml
@@ -68,7 +68,6 @@
       - "{{ node_custom_config }}/monasca/agent_plugins/"
       - "{{ node_custom_config }}/monasca/{{ inventory_hostname }}/agent_plugins/"
     patterns: '*.yaml'
-  run_once: True
   register: agent_plugins
 
 - name: Copying over monasca-agent-collector plugins


### PR DESCRIPTION
The results from the find operation need to be registered per host,
because they depend on the host which runs the search. This bug
impacts users specifying custom plugins for specific hosts.

Change-Id: I41b2986b2f4ccd8fdc6553e83737e4106b6a2c07
(cherry picked from commit 4be219fcb7f3ed188ea0c4c5b2cb9a1fdba51991)

Who wrote this stuff..