### PR TITLE
Fix rabbitmq-env.conf ownership in bifrost

### DIFF
--- a/ansible/roles/bifrost/tasks/bootstrap.yml
+++ b/ansible/roles/bifrost/tasks/bootstrap.yml
@@ -17,6 +17,7 @@
      docker exec bifrost_deploy
      bash -c '/bifrost/scripts/env-setup.sh && source /bifrost/env-vars
      && cp /etc/bifrost/rabbitmq-env.conf /etc/rabbitmq/rabbitmq-env.conf &&
+     chown rabbitmq:rabbitmq /etc/rabbitmq/rabbitmq-env.conf &&
      ansible-playbook -vvvv -i /bifrost/playbooks/inventory/target
      /bifrost/playbooks/install.yaml -e @/etc/bifrost/bifrost.yml
      -e @/etc/bifrost/dib.yml -e  skip_package_install=true'


### PR DESCRIPTION
The permissions of rabbitmq-env.conf for bifrost were changed in
I6e32d94d4172dd96d09d8609e8a5221ab5586a31 to 0660. This breaks bifrost
deployment, as the rabbitmq user is no longer able to read the
root-owned file on startup.

This commit changes the ownership of the file in the container to
rabbitmq:rabbitmq after it has been copied.

NOTE(priteau): In our stackhpc/queens branch, the change which caused
the issue is actually Id276ac1864f280554e98b937f2845bb424d521de.

Change-Id: I53418f5d4e40b7ca57e546e2e92a57f613fd381e
Closes-Bug: #1766196
(cherry picked from commit 746a2e0900ef5bc59cc66cee64ec13c331a166b8)