### PR TITLE
Retry perform a synced flush task while upgrading elasticsearch

### DIFF
--- a/ansible/roles/elasticsearch/tasks/upgrade.yml
+++ b/ansible/roles/elasticsearch/tasks/upgrade.yml
@@ -21,6 +21,10 @@
     body_format: json
   delegate_to: "{{ groups['elasticsearch'][0] }}"
   run_once: true
+  retries: 10
+  delay: 5
+  register: result
+  until: ('status' in result) and result.status == 200
 
 # Stop all elasticsearch containers before applying configuration to ensure
 # handlers are triggered to restart them.


### PR DESCRIPTION
The synced flush fails due to concurrent indexing operations.
The HTTP status code in that case will be 409 CONFLICT. We can
retry this task until returns success.

Change-Id: I57f9a009b12715eed8dfcf829a71f418d2ce437b
(cherry picked from commit adb02958e7337aae3dd9d10843c2cb20fb55980b)