### PR TITLE
Reduce number of logging errors

### DIFF
--- a/ansible/roles/common/tasks/config.yml
+++ b/ansible/roles/common/tasks/config.yml
@@ -56,6 +56,7 @@
     - "06-zookeeper"
     - "07-kafka"
     - "08-opendaylight"
+    - "09-monasca"
   notify:
     - Restart fluentd container
 

--- a/ansible/roles/common/templates/conf/filter/00-record_transformer.conf.j2
+++ b/ansible/roles/common/templates/conf/filter/00-record_transformer.conf.j2
@@ -36,6 +36,22 @@
     </record>
 </filter>
 
+# Rename internal Fluent message field to match other logs
+<filter fluent.**>
+    @type parser
+    key_name message
+    format /^(?<Payload>.*)$/
+</filter>
+
+<filter fluent.**>
+    @type record_transformer
+    <record>
+        Hostname "#{Socket.gethostname}"
+        programname ${tag_parts[0]}
+        log_level ${tag_parts[1]}
+    </record>
+</filter>
+
 {% if enable_monasca | bool %}
 # Kolla configures Fluentd to extract timestamps from OpenStack service
 # logs, however these timestamps are not saved in the event and are not

--- a/ansible/roles/common/templates/conf/filter/01-rewrite-0.12.conf.j2
+++ b/ansible/roles/common/templates/conf/filter/01-rewrite-0.12.conf.j2
@@ -33,4 +33,5 @@
     rewriterule30 programname ^(tacker-server|tacker-conductor)$ openstack_python
     rewriterule31 programname ^(vitrage-collector|vitrage-ml|vitrage-notifier|vitrage-graph)$ openstack_python
     rewriterule32 programname ^(blazar-api|blazar-manager)$ openstack_python
+    rewriterule33 programname ^(agent-collector|agent-forwarder|agent-statsd)$ openstack_python
 </match>

--- a/ansible/roles/common/templates/conf/filter/01-rewrite-0.12.conf.j2
+++ b/ansible/roles/common/templates/conf/filter/01-rewrite-0.12.conf.j2
@@ -33,5 +33,5 @@
     rewriterule30 programname ^(tacker-server|tacker-conductor)$ openstack_python
     rewriterule31 programname ^(vitrage-collector|vitrage-ml|vitrage-notifier|vitrage-graph)$ openstack_python
     rewriterule32 programname ^(blazar-api|blazar-manager)$ openstack_python
-    rewriterule33 programname ^(agent-collector|agent-forwarder|agent-statsd)$ openstack_python
+    rewriterule33 programname ^(monasca-api|monasca-notification|monasca-persister|agent-collector|agent-forwarder|agent-statsd)$ openstack_python
 </match>

--- a/ansible/roles/common/templates/conf/filter/01-rewrite-0.12.conf.j2
+++ b/ansible/roles/common/templates/conf/filter/01-rewrite-0.12.conf.j2
@@ -34,4 +34,5 @@
     rewriterule31 programname ^(vitrage-collector|vitrage-ml|vitrage-notifier|vitrage-graph)$ openstack_python
     rewriterule32 programname ^(blazar-api|blazar-manager)$ openstack_python
     rewriterule33 programname ^(monasca-api|monasca-notification|monasca-persister|agent-collector|agent-forwarder|agent-statsd)$ openstack_python
+    rewriterule34 programname .+ unmatched
 </match>

--- a/ansible/roles/common/templates/conf/filter/01-rewrite-0.14.conf.j2
+++ b/ansible/roles/common/templates/conf/filter/01-rewrite-0.14.conf.j2
@@ -161,4 +161,9 @@
     pattern ^(blazar-api|blazar-manager)$
     tag openstack_python
   </rule>
+  <rule>
+    key     programname
+    pattern ^(agent-collector|agent-forwarder|agent-statsd)$
+    tag openstack_python
+  </rule>
 </match>

--- a/ansible/roles/common/templates/conf/filter/01-rewrite-0.14.conf.j2
+++ b/ansible/roles/common/templates/conf/filter/01-rewrite-0.14.conf.j2
@@ -166,4 +166,9 @@
     pattern ^(monasca-api|monasca-notification|monasca-persister|agent-collector|agent-forwarder|agent-statsd)$
     tag openstack_python
   </rule>
+  <rule>
+    key     programname
+    pattern .+
+    tag unmatched
+  </rule>
 </match>

--- a/ansible/roles/common/templates/conf/filter/01-rewrite-0.14.conf.j2
+++ b/ansible/roles/common/templates/conf/filter/01-rewrite-0.14.conf.j2
@@ -163,7 +163,7 @@
   </rule>
   <rule>
     key     programname
-    pattern ^(agent-collector|agent-forwarder|agent-statsd)$
+    pattern ^(monasca-api|monasca-notification|monasca-persister|agent-collector|agent-forwarder|agent-statsd)$
     tag openstack_python
   </rule>
 </match>

--- a/ansible/roles/common/templates/conf/input/00-global.conf.j2
+++ b/ansible/roles/common/templates/conf/input/00-global.conf.j2
@@ -43,6 +43,7 @@
   path {% for service, enabled in services if enabled | bool %}/var/log/kolla/{{ service }}/*.log{% if not loop.last %},{% endif %}{% endfor %}
   exclude_path ["/var/log/kolla/monasca/agent*.log",
                 "/var/log/kolla/monasca/grafana.log",
+                "/var/log/kolla/monasca/monasca-log-api.log",
                 "/var/log/kolla/neutron/dnsmasq.log",
                 "/var/log/kolla/*/*-access.log",
                 "/var/log/kolla/*/*-error.log"]

--- a/ansible/roles/common/templates/conf/input/00-global.conf.j2
+++ b/ansible/roles/common/templates/conf/input/00-global.conf.j2
@@ -41,7 +41,9 @@
 <source>
   @type tail
   path {% for service, enabled in services if enabled | bool %}/var/log/kolla/{{ service }}/*.log{% if not loop.last %},{% endif %}{% endfor %}
-  exclude_path ["/var/log/kolla/neutron/dnsmasq.log",
+  exclude_path ["/var/log/kolla/monasca/agent*.log",
+                "/var/log/kolla/monasca/grafana.log",
+                "/var/log/kolla/neutron/dnsmasq.log",
                 "/var/log/kolla/*/*-access.log",
                 "/var/log/kolla/*/*-error.log"]
   pos_file /var/run/{{ fluentd_dir }}/kolla-openstack.pos

--- a/ansible/roles/common/templates/conf/input/09-monasca.conf.j2
+++ b/ansible/roles/common/templates/conf/input/09-monasca.conf.j2
@@ -1,0 +1,22 @@
+<source>
+  @type tail
+  path /var/log/kolla/monasca/agent*.log
+  pos_file /var/run/fluentd/monasca-agent.pos
+  tag kolla.*
+  format multiline
+  format_firstline /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \S+ \| \S+ \| \S+ \| .*$/
+  format1 /^(?<Timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \S+) \| (?<log_level>\S+) \| (?<programname>\S+) \| (?<Payload>.*)$/
+  time_key Timestamp
+</source>
+
+<source>
+  @type tail
+  path /var/log/kolla/monasca/grafana.log
+  pos_file /var/run/fluentd/monasca-grafana.pos
+  tag infra.*
+  format multiline
+  format_firstline /^t=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{4} lvl=\S+ msg=.*$/
+  format1 /^t=(?<Timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{4}) lvl=(?<log_level>\S+) msg=(?<Payload>.*)$/
+  time_key Timestamp
+</source>
+

--- a/ansible/roles/common/templates/fluentd.json.j2
+++ b/ansible/roles/common/templates/fluentd.json.j2
@@ -43,6 +43,12 @@
             "owner": "{{ fluentd_user }}",
             "perm": "0600"
         },
+        {
+            "source": "{{ container_config_directory }}/input/09-monasca.conf",
+            "dest": "{{ fluentd_dir }}/input/09-monasca.conf",
+            "owner": "{{ fluentd_user }}",
+            "perm": "0600"
+        },
         {# Copy all configuration files in filter/ directory to include #}
         {# custom filter configs. #}
         {


### PR DESCRIPTION
Monasca Agent and Monasca Grafana do not use Oslo log resulting in
parsing errors in the Fluentd docker logs. This change parses these
log files separately to prevent these errors.