### PR TITLE
Enable buffering to file for Monasca logs

### DIFF
--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -14,6 +14,7 @@ common_services:
       - "{{ node_config_directory }}/fluentd/:{{ container_config_directory }}/:ro"
       - "/etc/localtime:/etc/localtime:ro"
       - "kolla_logs:/var/log/kolla/"
+      - "fluentd_data:/var/lib/fluentd/data/"
     dimensions: "{{ fluentd_dimensions }}"
   kolla-toolbox:
     container_name: kolla_toolbox

--- a/ansible/roles/common/templates/conf/output/00-local.conf.j2
+++ b/ansible/roles/common/templates/conf/output/00-local.conf.j2
@@ -28,6 +28,9 @@
        domain_id default
        project_name {{ monasca_control_plane_project }}
        message_field_name Payload
+       buffer_type file
+       buffer_path /var/lib/fluentd/data/syslog-swift-monasca.*.buffer
+       max_retry_wait 1800s
     </store>
 {% endif %}
 </match>
@@ -64,6 +67,9 @@
        domain_id default
        project_name {{ monasca_control_plane_project }}
        message_field_name Payload
+       buffer_type file
+       buffer_path /var/lib/fluentd/data/syslog-haproxy-monasca.*.buffer
+       max_retry_wait 1800s
     </store>
 {% endif %}
 </match>

--- a/ansible/roles/common/templates/conf/output/02-monasca.conf.j2
+++ b/ansible/roles/common/templates/conf/output/02-monasca.conf.j2
@@ -10,5 +10,8 @@
        domain_id default
        project_name {{ monasca_control_plane_project }}
        message_field_name Payload
+       buffer_type file
+       buffer_path /var/lib/fluentd/data/monasca.*.buffer
+       max_retry_wait 1800s
     </store>
 </match>

--- a/ansible/roles/common/templates/fluentd.json.j2
+++ b/ansible/roles/common/templates/fluentd.json.j2
@@ -88,6 +88,11 @@
             "path": "/var/log/kolla/swift",
             "owner": "{{ fluentd_user }}:{{ fluentd_user }}",
             "recurse": true
+        },
+        {
+            "path": "/var/lib/fluentd/data",
+            "owner": "{{ fluentd_user }}:{{ fluentd_user }}",
+            "recurse": true
         }
     ]
 


### PR DESCRIPTION
This enables buffering to file, rather than memory for Monasca logs.
A dedicated docker volume is used for the file buffer. If a post
to the Monasca Log API fails, retries will be made using an exponential
backoff algorithm with a maximum retry interval of 30mins. The maximum
interval is set relatively low to try and reduce the risk of large
buffers accumulating, and therefore the risk of overloading the Monasca
Log API.