### PR TITLE
Disable Fluentd Monasca plugin retry limit

### DIFF
--- a/ansible/roles/common/templates/conf/output/00-local.conf.j2
+++ b/ansible/roles/common/templates/conf/output/00-local.conf.j2
@@ -31,6 +31,7 @@
        buffer_type file
        buffer_path /var/lib/fluentd/data/syslog-swift-monasca.*.buffer
        max_retry_wait 1800s
+       disable_retry_limit true
     </store>
 {% endif %}
 </match>
@@ -70,6 +71,7 @@
        buffer_type file
        buffer_path /var/lib/fluentd/data/syslog-haproxy-monasca.*.buffer
        max_retry_wait 1800s
+       disable_retry_limit true
     </store>
 {% endif %}
 </match>

--- a/ansible/roles/common/templates/conf/output/02-monasca.conf.j2
+++ b/ansible/roles/common/templates/conf/output/02-monasca.conf.j2
@@ -13,5 +13,6 @@
        buffer_type file
        buffer_path /var/lib/fluentd/data/monasca.*.buffer
        max_retry_wait 1800s
+       disable_retry_limit true
     </store>
 </match>


### PR DESCRIPTION
By default a retry limit of 17 exists. When the limit is reached buffered
logs are discarded. To avoid this, we disable the retry limit. The risk of
bringing down the host by filling the Fluent data docker volume is managed
by the maximum buffer size which is 2GB by default.