### PR TITLE
Cherry pick patches on stackhpc/rocky to stable/stein

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+---
+language: python
+python: "2.7"
+
+# Run jobs in VMs - sudo is required by ansible tests.
+sudo: required
+
+# Install ansible
+addons:
+  apt:
+    packages:
+      - gcc
+      - python-apt
+      - python-virtualenv
+      - realpath
+
+# Create a build matrix for the different test jobs.
+env:
+  matrix:
+    # Run python style checks.
+    - TOX_ENV=pep8
+    # Build documentation.
+    - TOX_ENV=docs
+    # Run python2.7 unit tests.
+    - TOX_ENV=py27
+
+install:
+  # Install tox in a virtualenv to ensure we have an up to date version.
+  - pip install -U pip
+  - pip install tox
+
+script:
+  # Run the tox environment.
+  - tox -e ${TOX_ENV}

--- a/ansible/roles/aodh/tasks/bootstrap.yml
+++ b/ansible/roles/aodh/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ aodh_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['aodh-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/barbican/tasks/bootstrap.yml
+++ b/ansible/roles/barbican/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ barbican_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['barbican-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/blazar/tasks/bootstrap.yml
+++ b/ansible/roles/blazar/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ blazar_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['blazar-api'][0] }}"
 
@@ -55,4 +54,3 @@
   delegate_to: "{{ groups['blazar-api'][0] }}"
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed

--- a/ansible/roles/cinder/tasks/bootstrap.yml
+++ b/ansible/roles/cinder/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ cinder_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['cinder-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/cloudkitty/tasks/bootstrap.yml
+++ b/ansible/roles/cloudkitty/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ cloudkitty_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['cloudkitty-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/common/tasks/config.yml
+++ b/ansible/roles/common/tasks/config.yml
@@ -56,6 +56,7 @@
     - "06-zookeeper"
     - "07-kafka"
     - "08-opendaylight"
+    - "09-monasca"
   notify:
     - Restart fluentd container
 

--- a/ansible/roles/common/templates/conf/filter/00-record_transformer.conf.j2
+++ b/ansible/roles/common/templates/conf/filter/00-record_transformer.conf.j2
@@ -36,6 +36,27 @@
     </record>
 </filter>
 
+# Rename internal Fluent message field to match other logs. This removes
+# all other fields by default, including the original message field. This is
+# intented to avoid duplication of the log message and to prevent passing
+# invalid dimensions to Monasca, if it is enabled. Note that if this step
+# is moved to the format folder, then it will applied after the second step
+# below which will break the logic.
+<filter fluent.**>
+    @type parser
+    key_name message
+    format /^(?<Payload>.*)$/
+</filter>
+
+<filter fluent.**>
+    @type record_transformer
+    <record>
+        Hostname "#{Socket.gethostname}"
+        programname ${tag_parts[0]}
+        log_level ${tag_parts[1]}
+    </record>
+</filter>
+
 {% if enable_monasca | bool %}
 # Kolla configures Fluentd to extract timestamps from OpenStack service
 # logs, however these timestamps are not saved in the event and are not

--- a/ansible/roles/common/templates/conf/filter/01-rewrite-0.12.conf.j2
+++ b/ansible/roles/common/templates/conf/filter/01-rewrite-0.12.conf.j2
@@ -35,4 +35,5 @@
     rewriterule32 programname ^(blazar-api|blazar-manager)$ openstack_python
     rewriterule33 programname ^(cyborg-api|cyborg-conductor|cyborg-agent)$ openstack_python
     rewriterule34 programname ^(monasca-api|monasca-notification|monasca-persister|agent-collector|agent-forwarder|agent-statsd)$ openstack_python
+    rewriterule35 programname .+ unmatched
 </match>

--- a/ansible/roles/common/templates/conf/filter/01-rewrite-0.12.conf.j2
+++ b/ansible/roles/common/templates/conf/filter/01-rewrite-0.12.conf.j2
@@ -34,4 +34,5 @@
     rewriterule31 programname ^(vitrage-ml|vitrage-notifier|vitrage-graph)$ openstack_python
     rewriterule32 programname ^(blazar-api|blazar-manager)$ openstack_python
     rewriterule33 programname ^(cyborg-api|cyborg-conductor|cyborg-agent)$ openstack_python
+    rewriterule34 programname ^(agent-collector|agent-forwarder|agent-statsd)$ openstack_python
 </match>

--- a/ansible/roles/common/templates/conf/filter/01-rewrite-0.12.conf.j2
+++ b/ansible/roles/common/templates/conf/filter/01-rewrite-0.12.conf.j2
@@ -34,5 +34,5 @@
     rewriterule31 programname ^(vitrage-ml|vitrage-notifier|vitrage-graph)$ openstack_python
     rewriterule32 programname ^(blazar-api|blazar-manager)$ openstack_python
     rewriterule33 programname ^(cyborg-api|cyborg-conductor|cyborg-agent)$ openstack_python
-    rewriterule34 programname ^(agent-collector|agent-forwarder|agent-statsd)$ openstack_python
+    rewriterule34 programname ^(monasca-api|monasca-notification|monasca-persister|agent-collector|agent-forwarder|agent-statsd)$ openstack_python
 </match>

--- a/ansible/roles/common/templates/conf/filter/01-rewrite-0.14.conf.j2
+++ b/ansible/roles/common/templates/conf/filter/01-rewrite-0.14.conf.j2
@@ -168,7 +168,7 @@
   </rule>
   <rule>
     key     programname
-    pattern ^(agent-collector|agent-forwarder|agent-statsd)$
+    pattern ^(monasca-api|monasca-notification|monasca-persister|agent-collector|agent-forwarder|agent-statsd)$
     tag openstack_python
   </rule>
 </match>

--- a/ansible/roles/common/templates/conf/filter/01-rewrite-0.14.conf.j2
+++ b/ansible/roles/common/templates/conf/filter/01-rewrite-0.14.conf.j2
@@ -166,4 +166,9 @@
     pattern ^(blazar-api|blazar-manager)$
     tag openstack_python
   </rule>
+  <rule>
+    key     programname
+    pattern ^(agent-collector|agent-forwarder|agent-statsd)$
+    tag openstack_python
+  </rule>
 </match>

--- a/ansible/roles/common/templates/conf/filter/01-rewrite-0.14.conf.j2
+++ b/ansible/roles/common/templates/conf/filter/01-rewrite-0.14.conf.j2
@@ -171,4 +171,9 @@
     pattern ^(monasca-api|monasca-notification|monasca-persister|agent-collector|agent-forwarder|agent-statsd)$
     tag openstack_python
   </rule>
+  <rule>
+    key     programname
+    pattern .+
+    tag unmatched
+  </rule>
 </match>

--- a/ansible/roles/common/templates/conf/input/00-global.conf.j2
+++ b/ansible/roles/common/templates/conf/input/00-global.conf.j2
@@ -43,7 +43,9 @@
 <source>
   @type tail
   path {% for service, enabled in services if enabled | bool %}/var/log/kolla/{{ service }}/*.log{% if not loop.last %},{% endif %}{% endfor %}
-  exclude_path ["/var/log/kolla/neutron/dnsmasq.log",
+  exclude_path ["/var/log/kolla/monasca/agent*.log",
+                "/var/log/kolla/monasca/grafana.log",
+                "/var/log/kolla/neutron/dnsmasq.log",
                 "/var/log/kolla/*/*-access.log",
                 "/var/log/kolla/*/*-error.log"]
   pos_file /var/run/{{ fluentd_dir }}/kolla-openstack.pos

--- a/ansible/roles/common/templates/conf/input/00-global.conf.j2
+++ b/ansible/roles/common/templates/conf/input/00-global.conf.j2
@@ -45,6 +45,7 @@
   path {% for service, enabled in services if enabled | bool %}/var/log/kolla/{{ service }}/*.log{% if not loop.last %},{% endif %}{% endfor %}
   exclude_path ["/var/log/kolla/monasca/agent*.log",
                 "/var/log/kolla/monasca/grafana.log",
+                "/var/log/kolla/monasca/monasca-log-api.log",
                 "/var/log/kolla/neutron/dnsmasq.log",
                 "/var/log/kolla/*/*-access.log",
                 "/var/log/kolla/*/*-error.log"]

--- a/ansible/roles/common/templates/conf/input/09-monasca.conf.j2
+++ b/ansible/roles/common/templates/conf/input/09-monasca.conf.j2
@@ -1,0 +1,22 @@
+<source>
+  @type tail
+  path /var/log/kolla/monasca/agent*.log
+  pos_file /var/run/fluentd/monasca-agent.pos
+  tag kolla.*
+  format multiline
+  format_firstline /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \S+ \| \S+ \| \S+ \| .*$/
+  format1 /^(?<Timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \S+) \| (?<log_level>\S+) \| (?<programname>\S+) \| (?<Payload>.*)$/
+  time_key Timestamp
+</source>
+
+<source>
+  @type tail
+  path /var/log/kolla/monasca/grafana.log
+  pos_file /var/run/fluentd/monasca-grafana.pos
+  tag infra.*
+  format multiline
+  format_firstline /^t=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{4} lvl=\S+ msg=.*$/
+  format1 /^t=(?<Timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{4}) lvl=(?<log_level>\S+) msg=(?<Payload>.*)$/
+  time_key Timestamp
+</source>
+

--- a/ansible/roles/common/templates/conf/output/00-local.conf.j2
+++ b/ansible/roles/common/templates/conf/output/00-local.conf.j2
@@ -31,6 +31,7 @@
        buffer_type file
        buffer_path /var/lib/fluentd/data/syslog-swift-monasca.*.buffer
        max_retry_wait 1800s
+       disable_retry_limit true
     </store>
 {% endif %}
 </match>
@@ -70,6 +71,7 @@
        buffer_type file
        buffer_path /var/lib/fluentd/data/syslog-haproxy-monasca.*.buffer
        max_retry_wait 1800s
+       disable_retry_limit true
     </store>
 {% endif %}
 </match>

--- a/ansible/roles/common/templates/conf/output/00-local.conf.j2
+++ b/ansible/roles/common/templates/conf/output/00-local.conf.j2
@@ -28,6 +28,9 @@
        domain_id default
        project_name {{ monasca_control_plane_project }}
        message_field_name Payload
+       buffer_type file
+       buffer_path /var/lib/fluentd/data/syslog-swift-monasca.*.buffer
+       max_retry_wait 1800s
     </store>
 {% endif %}
 </match>
@@ -64,6 +67,9 @@
        domain_id default
        project_name {{ monasca_control_plane_project }}
        message_field_name Payload
+       buffer_type file
+       buffer_path /var/lib/fluentd/data/syslog-haproxy-monasca.*.buffer
+       max_retry_wait 1800s
     </store>
 {% endif %}
 </match>

--- a/ansible/roles/common/templates/conf/output/02-monasca.conf.j2
+++ b/ansible/roles/common/templates/conf/output/02-monasca.conf.j2
@@ -13,5 +13,6 @@
        buffer_type file
        buffer_path /var/lib/fluentd/data/monasca.*.buffer
        max_retry_wait 1800s
+       disable_retry_limit true
     </store>
 </match>

--- a/ansible/roles/common/templates/conf/output/02-monasca.conf.j2
+++ b/ansible/roles/common/templates/conf/output/02-monasca.conf.j2
@@ -10,5 +10,8 @@
        domain_id default
        project_name {{ monasca_control_plane_project }}
        message_field_name Payload
+       buffer_type file
+       buffer_path /var/lib/fluentd/data/monasca.*.buffer
+       max_retry_wait 1800s
     </store>
 </match>

--- a/ansible/roles/congress/tasks/bootstrap.yml
+++ b/ansible/roles/congress/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ congress_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['congress-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/cyborg/tasks/bootstrap.yml
+++ b/ansible/roles/cyborg/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ cyborg_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['cyborg-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/designate/tasks/bootstrap.yml
+++ b/ansible/roles/designate/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ item }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['designate-central'][0] }}"
   with_items:
@@ -46,4 +45,3 @@
   no_log: true
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/glance/tasks/bootstrap.yml
+++ b/ansible/roles/glance/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ glance_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['glance-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/gnocchi/tasks/bootstrap.yml
+++ b/ansible/roles/gnocchi/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ gnocchi_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['gnocchi-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/heat/tasks/bootstrap.yml
+++ b/ansible/roles/heat/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ heat_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['heat-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/horizon/tasks/bootstrap.yml
+++ b/ansible/roles/horizon/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ horizon_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['horizon'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/ironic/tasks/bootstrap.yml
+++ b/ansible/roles/ironic/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ item.database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups[item.group][0] }}"
   with_items:
@@ -53,7 +52,6 @@
     - inventory_hostname in groups[item.group]
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed
 
 - name: Running Ironic-PXE bootstrap container
   vars:

--- a/ansible/roles/karbor/tasks/bootstrap.yml
+++ b/ansible/roles/karbor/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ karbor_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['karbor-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/keystone/tasks/bootstrap.yml
+++ b/ansible/roles/keystone/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ keystone_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['keystone'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/magnum/tasks/bootstrap.yml
+++ b/ansible/roles/magnum/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ magnum_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['magnum-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/manila/tasks/bootstrap.yml
+++ b/ansible/roles/manila/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ manila_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['manila-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/mistral/tasks/bootstrap.yml
+++ b/ansible/roles/mistral/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ mistral_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['mistral-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/monasca/handlers/main.yml
+++ b/ansible/roles/monasca/handlers/main.yml
@@ -66,6 +66,7 @@
     - config_json.changed | bool
       or monasca_log_transformer_confs.changed | bool
       or monasca_log_transformer_container.changed | bool
+      or monasca_custom_logstash_patterns_configured.changed | bool
 
 - name: Restart monasca-log-persister container
   vars:

--- a/ansible/roles/monasca/tasks/bootstrap.yml
+++ b/ansible/roles/monasca/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ item }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['monasca-api'][0] }}"
   with_items:
@@ -36,10 +35,8 @@
   delegate_to: "{{ groups['monasca-api'][0] }}"
   when:
     - not use_preconfigured_databases | bool
-    - database.changed
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool
 
 # NOTE(dszumski): Monasca is not yet compatible with InfluxDB > 1.1.10, which means
 # that the official Ansible modules for managing InfluxDB don't work [1].

--- a/ansible/roles/monasca/tasks/config.yml
+++ b/ansible/roles/monasca/tasks/config.yml
@@ -245,6 +245,7 @@
     src: "{{ item.path }}"
     dest: "{{ node_config_directory }}/monasca-log-transformer/logstash_patterns/{{ item.path | basename }}"
     mode: "0660"
+  become: true
   register: monasca_custom_logstash_patterns_configured
   with_items: "{{ monasca_custom_logstash_patterns.files }}"
   when:

--- a/ansible/roles/monasca/tasks/config.yml
+++ b/ansible/roles/monasca/tasks/config.yml
@@ -218,6 +218,41 @@
   notify:
     - Restart monasca-log-transformer container
 
+- name: Ensuring logstash patterns folder exists
+  vars:
+    service: "{{ monasca_services['monasca-log-transformer'] }}"
+  file:
+    path: "{{ node_config_directory }}/monasca-log-transformer/logstash_patterns"
+    state: "directory"
+    mode: "0770"
+  become: true
+  when:
+    - inventory_hostname in groups[service['group']]
+    - service.enabled | bool
+
+- name: Find custom logstash patterns
+  local_action:
+    module: find
+    path: "{{ node_custom_config }}/monasca/logstash_patterns"
+    pattern: "*"
+  run_once: True
+  register: monasca_custom_logstash_patterns
+
+- name: Copying over custom logstash patterns
+  vars:
+    service: "{{ monasca_services['monasca-log-transformer'] }}"
+  template:
+    src: "{{ item.path }}"
+    dest: "{{ node_config_directory }}/monasca-log-transformer/logstash_patterns/{{ item.path | basename }}"
+    mode: "0660"
+  register: monasca_custom_logstash_patterns_configured
+  with_items: "{{ monasca_custom_logstash_patterns.files }}"
+  when:
+    - inventory_hostname in groups[service['group']]
+    - service.enabled | bool
+  notify:
+    - Restart monasca-log-transformer container
+
 - name: Copying over monasca-log-persister config
   vars:
     service: "{{ monasca_services['monasca-log-persister'] }}"

--- a/ansible/roles/monasca/templates/monasca-log-transformer/monasca-log-transformer.json.j2
+++ b/ansible/roles/monasca/templates/monasca-log-transformer/monasca-log-transformer.json.j2
@@ -11,7 +11,8 @@
             "source": "{{ container_config_directory }}/logstash_patterns/*",
             "dest": "/etc/logstash/conf.d/patterns/",
             "owner": "logstash",
-            "perm": "0600"
+            "perm": "0600",
+            "optional": true
         }
     ],
     "permissions": [

--- a/ansible/roles/monasca/templates/monasca-log-transformer/monasca-log-transformer.json.j2
+++ b/ansible/roles/monasca/templates/monasca-log-transformer/monasca-log-transformer.json.j2
@@ -6,6 +6,12 @@
             "dest": "/etc/logstash/conf.d/log-transformer.conf",
             "owner": "logstash",
             "perm": "0600"
+        },
+        {
+            "source": "{{ container_config_directory }}/logstash_patterns/*",
+            "dest": "/etc/logstash/conf.d/patterns/",
+            "owner": "logstash",
+            "perm": "0600"
         }
     ],
     "permissions": [

--- a/ansible/roles/murano/tasks/bootstrap.yml
+++ b/ansible/roles/murano/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ murano_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['murano-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/neutron/tasks/bootstrap.yml
+++ b/ansible/roles/neutron/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ neutron_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['neutron-server'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/nova/tasks/bootstrap.yml
+++ b/ansible/roles/nova/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ item }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['nova-api'][0] }}"
   with_items:
@@ -48,9 +47,7 @@
   run_once: True
   delegate_to: "{{ groups['nova-api'][0] }}"
   when:
-    - database.changed
     - not use_preconfigured_databases | bool
   no_log: true
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/octavia/tasks/bootstrap.yml
+++ b/ansible/roles/octavia/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ octavia_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['octavia-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/panko/tasks/bootstrap.yml
+++ b/ansible/roles/panko/tasks/bootstrap.yml
@@ -20,7 +20,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ panko_database_name }}"
-  register: mysql_panko_database
   run_once: True
   delegate_to: "{{ groups['panko-api'][0] }}"
   when:
@@ -48,6 +47,3 @@
     - panko_database_type == "mysql"
 
 - include_tasks: bootstrap_service.yml
-  when: (panko_database_type == "mongodb" and mongodb_panko_database.changed)
-         or (panko_database_type == "mysql" and mysql_panko_database.changed)
-         or use_preconfigured_databases | bool

--- a/ansible/roles/placement/tasks/bootstrap.yml
+++ b/ansible/roles/placement/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ placement_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['placement-api'][0] }}"
   when:
@@ -32,7 +31,6 @@
   run_once: True
   delegate_to: "{{ groups['placement-api'][0] }}"
   when:
-    - database.changed
     - not use_preconfigured_databases | bool
 
 # TODO(egonzalez): Remove this task once stein is release as will not be required to migrate data.
@@ -64,4 +62,3 @@
     - kolla_action == "upgrade"
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/rally/tasks/bootstrap.yml
+++ b/ansible/roles/rally/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ rally_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['rally'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/sahara/tasks/bootstrap.yml
+++ b/ansible/roles/sahara/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ sahara_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['sahara-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/senlin/tasks/bootstrap.yml
+++ b/ansible/roles/senlin/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ senlin_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['senlin-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/solum/tasks/bootstrap.yml
+++ b/ansible/roles/solum/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ solum_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['solum-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/tacker/tasks/bootstrap.yml
+++ b/ansible/roles/tacker/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ tacker_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['tacker-server'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/trove/tasks/bootstrap.yml
+++ b/ansible/roles/trove/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ trove_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['trove-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/vitrage/tasks/bootstrap.yml
+++ b/ansible/roles/vitrage/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ vitrage_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['vitrage-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/watcher/tasks/bootstrap.yml
+++ b/ansible/roles/watcher/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ watcher_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['watcher-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool

--- a/ansible/roles/zun/tasks/bootstrap.yml
+++ b/ansible/roles/zun/tasks/bootstrap.yml
@@ -9,7 +9,6 @@
       login_user: "{{ database_user }}"
       login_password: "{{ database_password }}"
       name: "{{ zun_database_name }}"
-  register: database
   run_once: True
   delegate_to: "{{ groups['zun-api'][0] }}"
   when:
@@ -35,4 +34,3 @@
     - not use_preconfigured_databases | bool
 
 - include_tasks: bootstrap_service.yml
-  when: database.changed or use_preconfigured_databases | bool


### PR DESCRIPTION
rebase stackhpc/rocky on stable/rocky
========================================
pick a66c5dd84 Add travis.yml
pick 82c24817f Add Elasticsearch config for log-query-api
pick 4837cd047 Check that all log files are readable in kolla-ansible check
pick ed1cc5bb1 Set ramdisk logs path for ironic inspector
pick 48cc9e910 Fix elasticsearch server list in Monasca Log API
pick 283a09190 Add support for using custom Logstash patterns
pick c5081ba96 Add missing become: true
pick b9e72586f Support Ironic Inspector dnsmasq PXE filter
pick 934e9e331 Make logstash patterns optional
pick fb0f4fd04 Fix keystone fernet key rotation scheduling
pick c4199003f Move keystone doc to legacy location for patch backport
pick 918183277 Ingest non-standard Monasca logs
pick fd6c61635 Increase log coverage for Monasca
pick f0cf9eb9b Don't drop unmatched Kolla service logs
pick 0b147dad3 Format internal Fluentd logs
pick 70b8caeb1 Enable buffering to file for Monasca logs
pick cd04064ec Disable Fluentd Monasca plugin retry limit

don't pick
==========

1d64207e5 Find Monasca agent plugins locally
-----------------------------------------------------------------
[will@juno kolla-ansible]$ if [ $(git log gerrit/stable/stein --grep Ia25daafe2f82f5744646fd2eda2d255ccead814e | wc -l)  -gt 0 ]; then echo this is already upstream; fi 
this is already upstream

pick 149aaac9e Call Grafana APIs only once
-----------------------------------------------------------------
[will@juno kolla-ansible]$ if [ $(git log gerrit/stable/stein --grep I3a93a719b3c9b4e55ab226d3b22d571d9a0f489d | wc -l)  -gt 0 ]; then echo this is already upstream; fi 
this is already upstream

pick e6d8c11a3 Allow custom fluentd input configurations
------------------------------------------------------------------------------
[will@juno kolla-ansible]$ if [ $(git log gerrit/stable/stein --grep I2e5ecf5b01cc842ec480fc4d883a7d2283fc1c31 | wc -l)  -gt 0 ]; then echo this is already upstream; fi 
this is already upstream

pick d884402a4 Make tunnel timeout for nova_serialconsole_proxy configurable
----------------------------------------------------------

[will@juno kolla-ansible]$ if [ $(git log gerrit/stable/stein --grep I2a9923cb69d5db976395146685aded83922c4120 | wc -l)  -gt 0 ]; then echo this is already upstream; fi 
this is already upstream

pick 82c24817f Add Elasticsearch config for log-query-api
-------------------------------------------------------------------------------
can't see this change upstream - doug says: Not required - it has been abandoned for now

pick 48cc9e910 Fix elasticsearch server list in Monasca Log API
---------------------------------------------------------------------------------------
-  no upstream counterpart, see: 82c24817f

pick c4199003f Move keystone doc to legacy location for patch backport
----------------------------------------------------------------------------------------------------
 - unnecessary

pick 4837cd047 Check that all log files are readable in kolla-ansible check
-----------------------------------------------------------------------------------------------------
-  https://review.opendev.org/#/c/605381/ - never did get merged

I got bored of searching manually for change-ids and used:

```
while read -r line; do
    commit=`echo $line | awk '{ print $2}'`
    id=`git log --format=%B -n 1 $commit | grep Change-Id | awk '{print $2}'`
    if [ "$id" = "" ] || [ $(git log gerrit/stable/stein --grep $id | wc -l)  -eq 0 ]; then
        echo $line
    fi
done
```

to filter out a few.

picks
=====
pick a66c5dd84 Add travis.yml - for github only
pick 283a09190 Add support for using custom Logstash patterns - doesn't exist upstream
pick c5081ba96 Add missing become: true - related to 283a09190
pick 934e9e331 Make logstash patterns optional - related to 283a09190

cherry-pick upstream
==================
pick 918183277 Ingest non-standard Monasca logs - https://review.opendev.org/#/c/671077/1 - done
pick fd6c61635 Increase log coverage for Monasca - https://review.opendev.org/#/c/671070/ - done
pick f0cf9eb9b Don't drop unmatched Kolla service logs - https://review.opendev.org/#/c/671070/ - done
pick 0b147dad3 Format internal Fluentd logs - https://review.opendev.org/#/c/671078/ - done
pick 70b8caeb1 Enable buffering to file for Monasca logs - https://review.opendev.org/#/c/671081/1 - done
pick cd04064ec Disable Fluentd Monasca plugin retry limit - https://review.opendev.org/671082  - done