### PR TITLE
Monasca thresh data dir (Rocky)

### DIFF
--- a/ansible/roles/monasca/templates/monasca-thresh/monasca-thresh.json.j2
+++ b/ansible/roles/monasca/templates/monasca-thresh/monasca-thresh.json.j2
@@ -1,5 +1,5 @@
 {
-    "command": "/opt/storm/bin/storm jar /monasca-thresh-source/monasca-thresh-*/thresh/target/monasca-thresh-*-SNAPSHOT-shaded.jar monasca.thresh.ThresholdingEngine /etc/monasca/thresh-config.yml monasca-thresh local",
+    "command": "/opt/storm/bin/storm jar /monasca-thresh-source/monasca-thresh-*/thresh/target/monasca-thresh-*-SNAPSHOT-shaded.jar -Djava.io.tmpdir=/var/lib/monasca-thresh/data monasca.thresh.ThresholdingEngine /etc/monasca/thresh-config.yml monasca-thresh local",
     "config_files": [
         {
             "source": "{{ container_config_directory }}/thresh-config.yml",


### PR DESCRIPTION
Moves monasca-thresh java.io.tmpdir to existing docker volume

This prevents the container's root filesystem from filling up.