### PR TITLE
Removes monasca_grafana persistent volume

### DIFF
--- a/ansible/roles/monasca/defaults/main.yml
+++ b/ansible/roles/monasca/defaults/main.yml
@@ -124,7 +124,6 @@ monasca_services:
     volumes:
       - "{{ node_config_directory }}/monasca-grafana/:{{ container_config_directory }}/:ro"
       - "/etc/localtime:/etc/localtime:ro"
-      - "monasca_grafana:/var/lib/grafana/"
       - "kolla_logs:/var/log/kolla/"
     dimensions: "{{ monasca_grafana_dimensions }}"
 


### PR DESCRIPTION
The monasca_grafana docker volume currently persists across container
builds, causing changes to installed plugins during build to be ignored.
This change deletes the volume entirely and forces plugin changes to be
applied via rebuild.

Change-Id: I36e62235a085e5c1955fdb5ae31f603be8ba69bf