### PR TITLE
Moves monasca-thresh java.io.tmpdir to existing docker volume

### DIFF
--- a/ansible/roles/monasca/templates/monasca-thresh/monasca-thresh.json.j2
+++ b/ansible/roles/monasca/templates/monasca-thresh/monasca-thresh.json.j2
@@ -1,5 +1,5 @@
 {
-    "command": "/opt/storm/bin/storm jar /monasca-thresh-source/monasca-thresh-*/thresh/target/monasca-thresh-*-SNAPSHOT-shaded.jar monasca.thresh.ThresholdingEngine /etc/monasca/thresh-config.yml monasca-thresh local",
+    "command": "/opt/storm/bin/storm jar /monasca-thresh-source/monasca-thresh-*/thresh/target/monasca-thresh-*-SNAPSHOT-shaded.jar -Djava.io.tmpdir=/var/lib/monasca-thresh/data monasca.thresh.ThresholdingEngine /etc/monasca/thresh-config.yml monasca-thresh local",
     "config_files": [
         {
             "source": "{{ container_config_directory }}/thresh-config.yml",


### PR DESCRIPTION
This prevents the container's root filesystem from filling up.

Change-Id: Icc5a08c82312d6688edf2ef36562967ac94e8ac9
Depends-On: https://review.opendev.org/#/c/674779
Closes-Bug: #1839149
(cherry picked from commit df93d31fe06b8e6522f892281e57c4d4681b1975)