### PR TITLE
Enable gathering CPU load info in cAdvisor

### DIFF
--- a/ansible/roles/prometheus/defaults/main.yml
+++ b/ansible/roles/prometheus/defaults/main.yml
@@ -132,6 +132,15 @@ prometheus_services:
 prometheus_mysql_exporter_database_user: "{% if use_preconfigured_databases | bool and use_common_mariadb_user | bool %}{{ database_user }}{% else %}prometheus{% endif %}"
 
 ####################
+# cAdvisor
+####################
+
+# By default CPU load monitoring is disabled. This flag can be used to enable it. See
+# https://github.com/google/cadvisor/blob/release-v0.35/docs/runtime_options.md#cpu for more
+# details.
+prometheus_cadvisor_enable_load_monitoring: false
+
+####################
 # Docker
 ####################
 prometheus_install_type: "{{ kolla_install_type }}"

--- a/ansible/roles/prometheus/templates/prometheus-cadvisor.json.j2
+++ b/ansible/roles/prometheus/templates/prometheus-cadvisor.json.j2
@@ -1,5 +1,5 @@
 {
-    "command": "/opt/cadvisor --port={{ prometheus_cadvisor_port }} --log_dir=/var/log/kolla/prometheus",
+    "command": "/opt/cadvisor --enable_load_reader={{ prometheus_cadvisor_enable_load_monitoring | bool }} --port={{ prometheus_cadvisor_port }} --log_dir=/var/log/kolla/prometheus",
     "config_files": [],
     "permissions": [
         {

--- a/releasenotes/notes/support-gathering-cpu-load-info-bae4367712155230.yaml
+++ b/releasenotes/notes/support-gathering-cpu-load-info-bae4367712155230.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    A flag called `prometheus_cadvisor_enable_load_monitoring` has been added to enable
+    gathering of container CPU load metrics in cAdvisor.


### PR DESCRIPTION
It can be useful to monitor CPU load as a function of container. This
change adds a flag to enable such functionality in cAdvisor. The
default setting of disabling CPU load monitoring is maintained.

Change-Id: I3a4195261220c88b9f23678bbc459ceda766147b
(cherry picked from commit a2f4f75151ffd38fa6584b2e2634d3a80e652f4a)