### PR TITLE
Cherry picks on stein ported to train

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+---
+language: python
+python: "2.7"
+
+# Run jobs in VMs - sudo is required by ansible tests.
+sudo: required
+
+# Install ansible
+addons:
+  apt:
+    packages:
+      - gcc
+      - python-apt
+      - python-virtualenv
+      - realpath
+
+# Create a build matrix for the different test jobs.
+env:
+  matrix:
+    # Run python style checks.
+    - TOX_ENV=pep8
+    # Build documentation.
+    - TOX_ENV=docs
+    # Run python2.7 unit tests.
+    - TOX_ENV=py27
+
+install:
+  # Install tox in a virtualenv to ensure we have an up to date version.
+  - pip install -U pip
+  - pip install tox
+
+script:
+  # Run the tox environment.
+  - tox -e ${TOX_ENV}

--- a/ansible/roles/common/templates/conf/output/00-local.conf.j2
+++ b/ansible/roles/common/templates/conf/output/00-local.conf.j2
@@ -43,6 +43,7 @@
        domain_id default
        project_name {{ monasca_control_plane_project }}
        message_field_name Payload
+       disable_retry_limit true
     </store>
 {% endif %}
 </match>
@@ -94,6 +95,7 @@
        domain_id default
        project_name {{ monasca_control_plane_project }}
        message_field_name Payload
+       disable_retry_limit true
     </store>
 {% endif %}
 </match>

--- a/ansible/roles/common/templates/conf/output/00-local.conf.j2
+++ b/ansible/roles/common/templates/conf/output/00-local.conf.j2
@@ -43,6 +43,9 @@
        domain_id default
        project_name {{ monasca_control_plane_project }}
        message_field_name Payload
+       buffer_type file
+       buffer_path /var/lib/fluentd/data/monasca.buffer/{{ syslog_swift_facility }}.*
+       max_retry_wait 1800s
        disable_retry_limit true
     </store>
 {% endif %}
@@ -95,6 +98,9 @@
        domain_id default
        project_name {{ monasca_control_plane_project }}
        message_field_name Payload
+       buffer_type file
+       buffer_path /var/lib/fluentd/data/monasca.buffer/{{ syslog_haproxy_facility }}.*
+       max_retry_wait 1800s
        disable_retry_limit true
     </store>
 {% endif %}

--- a/ansible/roles/common/templates/conf/output/02-monasca.conf.j2
+++ b/ansible/roles/common/templates/conf/output/02-monasca.conf.j2
@@ -10,6 +10,9 @@
        domain_id default
        project_name {{ monasca_control_plane_project }}
        message_field_name Payload
+       buffer_type file
+       buffer_path /var/lib/fluentd/data/monasca.buffer/openstack.*
+       max_retry_wait 1800s
        disable_retry_limit true
     </store>
 </match>

--- a/ansible/roles/common/templates/conf/output/02-monasca.conf.j2
+++ b/ansible/roles/common/templates/conf/output/02-monasca.conf.j2
@@ -10,5 +10,6 @@
        domain_id default
        project_name {{ monasca_control_plane_project }}
        message_field_name Payload
+       disable_retry_limit true
     </store>
 </match>

--- a/releasenotes/notes/enable-buffering-to-file-for-monasca-logs-88ca66cc4d6cda3b.yaml
+++ b/releasenotes/notes/enable-buffering-to-file-for-monasca-logs-88ca66cc4d6cda3b.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Fluentd now buffers logs locally to file when the Monasca API is
+    unreachable.


### PR DESCRIPTION
- 7c34ebe67 Support deploying Elasticsearch Curator
   - already picked in 89d212ec9e51a2330b3e5bc8d27eb26e626edd90
- 57193fa4a Make logstash patterns optional
   - already in train https://github.com/openstack/kolla-ansible/commit/65b9756127416b1daf2f28189dbeaf9063f84918
- 221f0d4a6 Add missing become: true
   - included in https://github.com/openstack/kolla-ansible/commit/65b9756127416b1daf2f28189dbeaf9063f84918
- 050b12b9c Add travis.yml
- c208ed0c1 Disable Fluentd Monasca plugin retry limit
   - now upstream in ussuri: https://review.opendev.org/#/c/666803/
   - I've cherry-picked a vserion back to train: https://review.opendev.org/#/c/733845/2
- e976511d2 Enable buffering to file for Monasca logs
   - backport abandoned upstream as it was deemed to be a feature: https://review.opendev.org/#/c/712426/