### PR TITLE
Support using Logstash 6 image with Centos8

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -686,7 +686,7 @@ enable_trove_singletenant: "no"
 enable_vitrage: "no"
 enable_vmtp: "no"
 enable_watcher: "no"
-enable_zookeeper: "{{ enable_kafka | bool }}"
+enable_zookeeper: "{{ enable_kafka | bool or enable_storm | bool }}"
 enable_zun: "no"
 
 ovs_datapath: "{{ 'netdev' if enable_ovs_dpdk | bool else 'system' }}"

--- a/ansible/roles/barbican/templates/barbican-api.ini.j2
+++ b/ansible/roles/barbican/templates/barbican-api.ini.j2
@@ -6,6 +6,6 @@ lazy = true
 vacuum = true
 no-default-app = true
 memory-report = true
-plugins = python
+plugins = python{{ '3' if distro_python_version.startswith('3') else '' }}
 paste = config:/etc/barbican/barbican-api-paste.ini
 add-header = Connection: close

--- a/ansible/roles/baremetal/defaults/main.yml
+++ b/ansible/roles/baremetal/defaults/main.yml
@@ -80,11 +80,13 @@ ubuntu_pkg_removals:
  - lxc
  - libvirt-bin
  - open-iscsi
+ - "{% if enable_chrony | bool %}chrony{% endif %}"
 
 redhat_pkg_removals:
  - libvirt
  - libvirt-daemon
  - iscsi-initiator-utils
+ - "{% if enable_chrony | bool %}chrony{% endif %}"
 
 # Path to a virtualenv in which to install python packages. If None, a
 # virtualenv will not be used.

--- a/ansible/roles/baremetal/tasks/post-install.yml
+++ b/ansible/roles/baremetal/tasks/post-install.yml
@@ -146,6 +146,22 @@
     - ansible_distribution == "Ubuntu"
     - apparmor_libvirtd_profile.stat.exists
 
+- name: Get stat of chronyd apparmor profile
+  stat:
+    path: /etc/apparmor.d/usr.sbin.chronyd
+  register: apparmor_chronyd_profile
+  when:
+    - ansible_os_family == "Debian"
+    - enable_chrony | bool
+
+- name: Remove apparmor profile for chrony
+  command: apparmor_parser -R /etc/apparmor.d/usr.sbin.chronyd
+  become: True
+  when:
+    - ansible_os_family == "Debian"
+    - enable_chrony | bool
+    - apparmor_chronyd_profile.stat.exists
+
 - name: Create docker group
   group:
     name: docker

--- a/ansible/roles/ceilometer/tasks/config.yml
+++ b/ansible/roles/ceilometer/tasks/config.yml
@@ -301,6 +301,7 @@
     - "Restart {{ item.key }} container"
 
 - name: Copying VMware vCenter CA file
+  become: true
   vars:
     service: "{{ ceilometer_services['ceilometer-compute'] }}"
   copy:

--- a/ansible/roles/cinder/defaults/main.yml
+++ b/ansible/roles/cinder/defaults/main.yml
@@ -93,10 +93,6 @@ cinder_database_name: "cinder"
 cinder_database_user: "{% if use_preconfigured_databases | bool and use_common_mariadb_user | bool %}{{ database_user }}{% else %}cinder{% endif %}"
 cinder_database_address: "{{ database_address | put_address_in_context('url') }}:{{ database_port }}"
 
-# Max number of object to consider
-# when run online data migration
-# cinder_max_number_osm: ""
-
 ####################
 # Docker
 ####################

--- a/ansible/roles/cinder/tasks/upgrade.yml
+++ b/ansible/roles/cinder/tasks/upgrade.yml
@@ -22,7 +22,6 @@
     environment:
       KOLLA_OSM:
       KOLLA_CONFIG_STRATEGY: "{{ config_strategy }}"
-      MAX_NUMBER: "{{ cinder_max_number_osm | default(10) }}"
     image: "{{ cinder_api.image }}"
     labels:
       BOOTSTRAP:

--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -47,6 +47,7 @@ fluentd_elasticsearch_user: ""
 fluentd_elasticsearch_password: ""
 fluentd_elasticsearch_ssl_version: "TLSv1_2"
 fluentd_elasticsearch_ssl_verify: "true"
+fluentd_elasticsearch_cacert: "{{ openstack_cacert }}"
 
 ####################
 # Docker

--- a/ansible/roles/common/templates/conf/output/00-local.conf.j2
+++ b/ansible/roles/common/templates/conf/output/00-local.conf.j2
@@ -19,6 +19,9 @@
 {% if fluentd_elasticsearch_scheme == 'https' %}
        ssl_version {{ fluentd_elasticsearch_ssl_version }}
        ssl_verify {{ fluentd_elasticsearch_ssl_verify }}
+{% if fluentd_elasticsearch_cacert | length > 0 %}
+       ca_file {{ fluentd_elasticsearch_cacert }}
+{% endif %}
 {% endif %}
 {% if fluentd_elasticsearch_user != '' and fluentd_elasticsearch_password != ''%}
        user {{ fluentd_elasticsearch_user }}
@@ -74,6 +77,9 @@
 {% if fluentd_elasticsearch_scheme == 'https' %}
        ssl_version {{ fluentd_elasticsearch_ssl_version }}
        ssl_verify {{ fluentd_elasticsearch_ssl_verify }}
+{% if fluentd_elasticsearch_cacert | length > 0 %}
+       ca_file {{ fluentd_elasticsearch_cacert }}
+{% endif %}
 {% endif %}
 {% if fluentd_elasticsearch_user != '' and fluentd_elasticsearch_password != ''%}
        user {{ fluentd_elasticsearch_user }}

--- a/ansible/roles/common/templates/conf/output/01-es.conf.j2
+++ b/ansible/roles/common/templates/conf/output/01-es.conf.j2
@@ -11,6 +11,9 @@
 {% if fluentd_elasticsearch_scheme == 'https' %}
        ssl_version {{ fluentd_elasticsearch_ssl_version }}
        ssl_verify {{ fluentd_elasticsearch_ssl_verify }}
+{% if fluentd_elasticsearch_cacert | length > 0 %}
+       ca_file {{ fluentd_elasticsearch_cacert }}
+{% endif %}
 {% endif %}
 {% if fluentd_elasticsearch_user != '' and fluentd_elasticsearch_password != ''%}
        user {{ fluentd_elasticsearch_user }}

--- a/ansible/roles/elasticsearch/defaults/main.yml
+++ b/ansible/roles/elasticsearch/defaults/main.yml
@@ -65,8 +65,13 @@ elasticsearch_curator_hard_retention_period_days: 60
 ####################
 # Docker
 ####################
+# The elasticsearch6 image is available only for CentOS 7 and CentOS 8, and
+# provides a compatible migration point to CentOS 8, which only has
+# Elasticsearch 6.
+elasticsearch_use_v6: "{{ ansible_os_family == 'RedHat' and ansible_distribution_major_version | int >= 8 }}"
 elasticsearch_install_type: "{{ kolla_install_type }}"
-elasticsearch_image: "{{ docker_registry ~ '/' if docker_registry else '' }}{{ docker_namespace }}/{{ kolla_base_distro }}-{{ elasticsearch_install_type }}-elasticsearch"
+elasticsearch_image_name: "{{ 'elasticsearch6' if elasticsearch_use_v6 | bool else 'elasticsearch' }}"
+elasticsearch_image: "{{ docker_registry ~ '/' if docker_registry else '' }}{{ docker_namespace }}/{{ kolla_base_distro }}-{{ elasticsearch_install_type }}-{{ elasticsearch_image_name }}"
 elasticsearch_tag: "{{ openstack_tag }}"
 elasticsearch_image_full: "{{ elasticsearch_image }}:{{ elasticsearch_tag }}"
 

--- a/ansible/roles/elasticsearch/tasks/check-containers.yml
+++ b/ansible/roles/elasticsearch/tasks/check-containers.yml
@@ -10,8 +10,8 @@
     dimensions: "{{ item.value.dimensions }}"
     environment: "{{ item.value.environment|default(omit) }}"
   when:
-    - inventory_hostname in groups[item.value.group]
     - item.value.enabled | bool
+    - inventory_hostname in groups[item.value.group]
   with_dict: "{{ elasticsearch_services }}"
   notify:
     - "Restart {{ item.key }} container"

--- a/ansible/roles/elasticsearch/tasks/config.yml
+++ b/ansible/roles/elasticsearch/tasks/config.yml
@@ -8,8 +8,8 @@
     mode: "0770"
   become: true
   when:
-    - inventory_hostname in groups[item.value.group]
     - item.value.enabled | bool
+    - inventory_hostname in groups[item.value.group]
   with_dict: "{{ elasticsearch_services }}"
 
 - name: Copying over config.json files for services
@@ -19,8 +19,8 @@
     mode: "0660"
   become: true
   when:
-    - inventory_hostname in groups[item.value.group]
     - item.value.enabled | bool
+    - inventory_hostname in groups[item.value.group]
   with_dict: "{{ elasticsearch_services }}"
   notify:
     - Restart {{ item.key }} container
@@ -32,8 +32,8 @@
     mode: "0660"
   become: true
   when:
-    - inventory_hostname in groups[item.value.group]
     - item.value.enabled | bool
+    - inventory_hostname in groups[item.value.group]
   with_dict: "{{ elasticsearch_services }}"
   notify:
     - Restart {{ item.key }} container

--- a/ansible/roles/elasticsearch/tasks/pull.yml
+++ b/ansible/roles/elasticsearch/tasks/pull.yml
@@ -6,6 +6,6 @@
     common_options: "{{ docker_common_options }}"
     image: "{{ item.value.image }}"
   when:
-    - inventory_hostname in groups[item.value.group]
     - item.value.enabled | bool
+    - inventory_hostname in groups[item.value.group]
   with_dict: "{{ elasticsearch_services }}"

--- a/ansible/roles/elasticsearch/tasks/upgrade.yml
+++ b/ansible/roles/elasticsearch/tasks/upgrade.yml
@@ -1,9 +1,13 @@
 ---
+- name: Set fact for Elasticsearch URL
+  set_fact:
+    elasticsearch_url: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ elasticsearch_port }}"
+
 # The official procedure for upgrade elasticsearch:
-# https://www.elastic.co/guide/en/elasticsearch/reference/5.6/restart-upgrade.html
+# https://www.elastic.co/guide/en/elasticsearch/reference/6.x/restart-upgrade.html
 - name: Disable shard allocation
   uri:
-    url: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ elasticsearch_port }}/_cluster/settings"
+    url: "{{ elasticsearch_url }}/_cluster/settings"
     method: PUT
     status_code: 200
     return_content: yes
@@ -14,7 +18,7 @@
 
 - name: Perform a synced flush
   uri:
-    url: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ elasticsearch_port }}/_flush/synced"
+    url: "{{ elasticsearch_url }}/_flush/synced"
     method: POST
     status_code: 200
     return_content: yes

--- a/ansible/roles/elasticsearch/templates/elasticsearch.json.j2
+++ b/ansible/roles/elasticsearch/templates/elasticsearch.json.j2
@@ -3,7 +3,7 @@
     "config_files": [
         {
             "source": "{{ container_config_directory }}/elasticsearch.yml",
-            "dest": "/usr/share/elasticsearch/config/elasticsearch.yml",
+            "dest": "{% if elasticsearch_use_v6 | bool %}/etc/elasticsearch/elasticsearch.yml{% else %}/usr/share/elasticsearch/config/elasticsearch.yml{% endif %}",
             "owner": "elasticsearch",
             "perm": "0600"
         }

--- a/ansible/roles/elasticsearch/templates/elasticsearch.yml.j2
+++ b/ansible/roles/elasticsearch/templates/elasticsearch.yml.j2
@@ -14,9 +14,11 @@ http.port: {{ elasticsearch_port }}
 gateway.expected_nodes: {{ num_nodes }}
 gateway.recover_after_time: "5m"
 gateway.recover_after_nodes: {{ recover_after_nodes }}
+{% if not elasticsearch_use_v6 | bool %}
 path.conf: "/etc/elasticsearch"
+path.scripts: "/etc/elasticsearch/scripts"
+{% endif %}
 path.data: "/var/lib/elasticsearch/data"
 path.logs: "/var/log/kolla/elasticsearch"
-path.scripts: "/etc/elasticsearch/scripts"
 indices.fielddata.cache.size: 40%
 action.auto_create_index: "true"

--- a/ansible/roles/grafana/tasks/post_config.yml
+++ b/ansible/roles/grafana/tasks/post_config.yml
@@ -23,7 +23,7 @@
   run_once: True
   changed_when: response.status == 200
   failed_when: response.status not in [200, 409] or
-               response.status == 409 and ("Data source with same name already exists" not in response.json.message|default(""))
+               response.status == 409 and ("name already exists" not in response.json.message|default(""))
   with_dict: "{{ grafana_data_sources }}"
   when: item.value.enabled | bool
 

--- a/ansible/roles/kibana/defaults/main.yml
+++ b/ansible/roles/kibana/defaults/main.yml
@@ -32,14 +32,18 @@ kibana_services:
 kibana_default_app_id: "discover"
 kibana_elasticsearch_request_timeout: 300000
 kibana_elasticsearch_shard_timeout: 0
-kibana_elasticsearch_ssl_verify: false
+kibana_elasticsearch_ssl_verify: true
 
 
 ####################
 # Docker
 ####################
+# The kibana6 image is available only for CentOS 7 and CentOS 8, and provides a
+# compatible migration point to CentOS 8, which only has Kibana 6.
+kibana_use_v6: "{{ ansible_os_family == 'RedHat' and ansible_distribution_major_version | int >= 8 }}"
 kibana_install_type: "{{ kolla_install_type }}"
-kibana_image: "{{ docker_registry ~ '/' if docker_registry else '' }}{{ docker_namespace }}/{{ kolla_base_distro }}-{{ kibana_install_type }}-kibana"
+kibana_image_name: "{{ 'kibana6' if kibana_use_v6 | bool else 'kibana' }}"
+kibana_image: "{{ docker_registry ~ '/' if docker_registry else '' }}{{ docker_namespace }}/{{ kolla_base_distro }}-{{ kibana_install_type }}-{{ kibana_image_name }}"
 kibana_tag: "{{ openstack_tag }}"
 kibana_image_full: "{{ kibana_image }}:{{ kibana_tag }}"
 kibana_dimensions: "{{ default_container_dimensions }}"

--- a/ansible/roles/kibana/files/kibana-6-index.json
+++ b/ansible/roles/kibana/files/kibana-6-index.json
@@ -1,0 +1,264 @@
+{
+  "settings" : {
+    "number_of_shards" : 1,
+    "index.mapper.dynamic": false
+  },
+  "mappings" : {
+    "doc": {
+      "properties": {
+        "type": {
+          "type": "keyword"
+        },
+        "updated_at": {
+          "type": "date"
+        },
+        "config": {
+          "properties": {
+            "buildNum": {
+              "type": "keyword"
+            }
+          }
+        },
+        "index-pattern": {
+          "properties": {
+            "fieldFormatMap": {
+              "type": "text"
+            },
+            "fields": {
+              "type": "text"
+            },
+            "intervalName": {
+              "type": "keyword"
+            },
+            "notExpandable": {
+              "type": "boolean"
+            },
+            "sourceFilters": {
+              "type": "text"
+            },
+            "timeFieldName": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "text"
+            }
+          }
+        },
+        "visualization": {
+          "properties": {
+            "description": {
+              "type": "text"
+            },
+            "kibanaSavedObjectMeta": {
+              "properties": {
+                "searchSourceJSON": {
+                  "type": "text"
+                }
+              }
+            },
+            "savedSearchId": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "text"
+            },
+            "uiStateJSON": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            },
+            "visState": {
+              "type": "text"
+            }
+          }
+        },
+        "search": {
+          "properties": {
+            "columns": {
+              "type": "keyword"
+            },
+            "description": {
+              "type": "text"
+            },
+            "hits": {
+              "type": "integer"
+            },
+            "kibanaSavedObjectMeta": {
+              "properties": {
+                "searchSourceJSON": {
+                  "type": "text"
+                }
+              }
+            },
+            "sort": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            }
+          }
+        },
+        "dashboard": {
+          "properties": {
+            "description": {
+              "type": "text"
+            },
+            "hits": {
+              "type": "integer"
+            },
+            "kibanaSavedObjectMeta": {
+              "properties": {
+                "searchSourceJSON": {
+                  "type": "text"
+                }
+              }
+            },
+            "optionsJSON": {
+              "type": "text"
+            },
+            "panelsJSON": {
+              "type": "text"
+            },
+            "refreshInterval": {
+              "properties": {
+                "display": {
+                  "type": "keyword"
+                },
+                "pause": {
+                  "type": "boolean"
+                },
+                "section": {
+                  "type": "integer"
+                },
+                "value": {
+                  "type": "integer"
+                }
+              }
+            },
+            "timeFrom": {
+              "type": "keyword"
+            },
+            "timeRestore": {
+              "type": "boolean"
+            },
+            "timeTo": {
+              "type": "keyword"
+            },
+            "title": {
+              "type": "text"
+            },
+            "uiStateJSON": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            }
+          }
+        },
+        "url": {
+          "properties": {
+            "accessCount": {
+              "type": "long"
+            },
+            "accessDate": {
+              "type": "date"
+            },
+            "createDate": {
+              "type": "date"
+            },
+            "url": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 2048
+                }
+              }
+            }
+          }
+        },
+        "server": {
+          "properties": {
+            "uuid": {
+              "type": "keyword"
+            }
+          }
+        },
+        "timelion-sheet": {
+          "properties": {
+            "description": {
+              "type": "text"
+            },
+            "hits": {
+              "type": "integer"
+            },
+            "kibanaSavedObjectMeta": {
+              "properties": {
+                "searchSourceJSON": {
+                  "type": "text"
+                }
+              }
+            },
+            "timelion_chart_height": {
+              "type": "integer"
+            },
+            "timelion_columns": {
+              "type": "integer"
+            },
+            "timelion_interval": {
+              "type": "keyword"
+            },
+            "timelion_other_interval": {
+              "type": "keyword"
+            },
+            "timelion_rows": {
+              "type": "integer"
+            },
+            "timelion_sheet": {
+              "type": "text"
+            },
+            "title": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            }
+          }
+        },
+        "graph-workspace": {
+          "properties": {
+            "description": {
+              "type": "text"
+            },
+            "kibanaSavedObjectMeta": {
+              "properties": {
+                "searchSourceJSON": {
+                  "type": "text"
+                }
+              }
+            },
+            "numLinks": {
+              "type": "integer"
+            },
+            "numVertices": {
+              "type": "integer"
+            },
+            "title": {
+              "type": "text"
+            },
+            "version": {
+              "type": "integer"
+            },
+            "wsState": {
+              "type": "text"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/ansible/roles/kibana/tasks/migrate-kibana-index.yml
+++ b/ansible/roles/kibana/tasks/migrate-kibana-index.yml
@@ -1,0 +1,99 @@
+---
+- name: Set fact for Elasticsearch URL
+  set_fact:
+    elasticsearch_url: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ elasticsearch_port }}"
+
+- name: Wait for Elasticsearch
+  become: true
+  uri:
+    url: "{{ elasticsearch_url }}"
+  delegate_to: "{{ groups['elasticsearch'][0] }}"
+  run_once: true
+  retries: 10
+  delay: 5
+  register: result
+  until: ('status' in result) and result.status == 200
+
+- name: Check state of migration
+  become: true
+  uri:
+    url: "{{ elasticsearch_url }}/.kibana/_mappings/doc"
+    status_code: [200, 404]
+  delegate_to: "{{ groups['elasticsearch'][0] }}"
+  run_once: true
+  register: kibana_6_index
+
+# The official procedure for migrating the Kibana index:
+# https://www.elastic.co/guide/en/kibana/6.x/migrating-6.0-index.html
+- name: Migrate Kibana index to 6.x
+  block:
+    - name: Set .kibana index to read-only
+      become: true
+      uri:
+        url: "{{ elasticsearch_url }}/.kibana/_settings"
+        method: PUT
+        status_code: 200
+        return_content: yes
+        body: |
+          {
+            "index.blocks.write": true
+          }
+        body_format: json
+      delegate_to: "{{ groups['elasticsearch'][0] }}"
+      run_once: true
+
+    - name: Create .kibana-6 index
+      become: true
+      uri:
+        url: "{{ elasticsearch_url }}/.kibana-6"
+        method: PUT
+        status_code: 200
+        return_content: yes
+        body: "{{ lookup('file', 'kibana-6-index.json') }}"
+        body_format: json
+      delegate_to: "{{ groups['elasticsearch'][0] }}"
+      run_once: true
+
+    - name: Reindex .kibana into .kibana-6
+      become: true
+      uri:
+        url: "{{ elasticsearch_url }}/_reindex"
+        method: POST
+        status_code: 200
+        return_content: yes
+        body: |
+          {
+            "source": {
+              "index": ".kibana"
+            },
+            "dest": {
+              "index": ".kibana-6"
+            },
+            "script": {
+              "inline": "ctx._source = [ ctx._type : ctx._source ]; ctx._source.type = ctx._type; ctx._id = ctx._type + \":\" + ctx._id; ctx._type = \"doc\"; ",
+              "lang": "painless"
+            }
+          }
+        body_format: json
+      delegate_to: "{{ groups['elasticsearch'][0] }}"
+      run_once: true
+
+    - name: Alias .kibana-6 to .kibana and remove legacy .kibana index
+      become: true
+      uri:
+        url: "{{ elasticsearch_url }}/_aliases"
+        method: POST
+        status_code: 200
+        return_content: yes
+        body: |
+          {
+            "actions" : [
+              { "add":  { "index": ".kibana-6", "alias": ".kibana" } },
+              { "remove_index": { "index": ".kibana" } }
+            ]
+          }
+        body_format: json
+      delegate_to: "{{ groups['elasticsearch'][0] }}"
+      run_once: true
+
+  when: ('status' in kibana_6_index) and kibana_6_index.status != 200

--- a/ansible/roles/kibana/tasks/upgrade.yml
+++ b/ansible/roles/kibana/tasks/upgrade.yml
@@ -1,5 +1,8 @@
 ---
 - include_tasks: config.yml
 
+- include_tasks: migrate-kibana-index.yml
+  when: kibana_use_v6 | bool
+
 - name: Flush handlers
   meta: flush_handlers

--- a/ansible/roles/magnum/templates/magnum.conf.j2
+++ b/ansible/roles/magnum/templates/magnum.conf.j2
@@ -23,12 +23,21 @@ max_retries = -1
 default_docker_volume_type = {{ default_docker_volume_type }}
 {% endif %}
 
+[magnum_client]
+region_name = {{ openstack_region_name }}
+endpoint_type = internalURL
+
 [heat_client]
+region_name = {{ openstack_region_name }}
+endpoint_type = internalURL
+
+[octavia_client]
 region_name = {{ openstack_region_name }}
 endpoint_type = internalURL
 
 [cinder_client]
 region_name = {{ openstack_region_name }}
+endpoint_type = internalURL
 
 [barbican_client]
 region_name = {{ openstack_region_name }}
@@ -74,6 +83,7 @@ memcached_servers = {% for host in groups['memcached'] %}{{ 'api' | kolla_addres
 trustee_domain_admin_password = {{ magnum_keystone_password }}
 trustee_domain_admin_name = {{ magnum_trustee_domain_admin }}
 trustee_domain_name = {{ magnum_trustee_domain }}
+trustee_keystone_region_name = {{ openstack_region_name }}
 cluster_user_trust = {{ enable_cluster_user_trust }}
 
 [oslo_concurrency]

--- a/ansible/roles/monasca/defaults/main.yml
+++ b/ansible/roles/monasca/defaults/main.yml
@@ -215,7 +215,11 @@ monasca_log_api_image: "{{ docker_registry ~ '/' if docker_registry else '' }}{{
 monasca_log_api_tag: "{{ monasca_tag }}"
 monasca_log_api_image_full: "{{ monasca_log_api_image }}:{{ monasca_log_api_tag }}"
 
-monasca_logstash_image: "{{ docker_registry ~ '/' if docker_registry else '' }}{{ docker_namespace }}/{{ kolla_base_distro }}-{{ kolla_install_type }}-logstash"
+# The logstash6 image is available for CentOS 7 and CentOS 8, and provides a
+# compatible migration point to CentOS 8, which only has Logstash 6.
+monasca_logstash_use_v6: "{{ ansible_os_family == 'RedHat' and ansible_distribution_major_version | int >= 8 }}"
+monasca_logstash_image_name: "{{ 'logstash6' if monasca_logstash_use_v6 | bool else 'logstash' }}"
+monasca_logstash_image: "{{ docker_registry ~ '/' if docker_registry else '' }}{{ docker_namespace }}/{{ kolla_base_distro }}-{{ kolla_install_type }}-{{ monasca_logstash_image_name }}"
 monasca_logstash_tag: "{{ monasca_tag }}"
 monasca_logstash_image_full: "{{ monasca_logstash_image }}:{{ monasca_logstash_tag }}"
 

--- a/ansible/roles/monasca/tasks/post_config.yml
+++ b/ansible/roles/monasca/tasks/post_config.yml
@@ -89,6 +89,7 @@
   run_once: True
   changed_when: monasca_grafana_datasource_response.status == 200
   failed_when: monasca_grafana_datasource_response.status not in [200, 409] or
-               monasca_grafana_datasource_response.status == 409 and ("Data source with same name already exists" not in  monasca_grafana_datasource_response.json.message|default(""))
+               (monasca_grafana_datasource_response.status == 409 and
+               "name already exists" not in monasca_grafana_datasource_response.json.message|default(""))
   with_dict: "{{ monasca_grafana_data_sources }}"
   when: item.value.enabled | bool

--- a/ansible/roles/monasca/templates/monasca-agent-forwarder/agent-forwarder.yml.j2
+++ b/ansible/roles/monasca/templates/monasca-agent-forwarder/agent-forwarder.yml.j2
@@ -10,7 +10,7 @@ Api:
   project_domain_id: {{ default_project_domain_id }}
   project_domain_name: {{ default_project_domain_name }}
   insecure: False
-  ca_file: /var/lib/kolla/venv/lib/python' ~ distro_python_version ~ '/site-packages/certifi/cacert.pem
+  ca_file: /var/lib/kolla/venv/lib/python{{ distro_python_version }}/site-packages/certifi/cacert.pem
   max_measurement_buffer_size: {{ monasca_agent_max_buffer_size }}
   backlog_send_rate: {{ monasca_agent_backlog_send_rate }}
   max_batch_size: {{ monasca_agent_max_batch_size }}

--- a/ansible/roles/monasca/templates/monasca-log-metrics/log-metrics.conf.j2
+++ b/ansible/roles/monasca/templates/monasca-log-metrics/log-metrics.conf.j2
@@ -7,6 +7,18 @@
 # example, if HAProxy fails over, file system corruption is detected or
 # other scenarios of interest.
 
+{% if monasca_logstash_use_v6 %}
+input {
+    kafka {
+        bootstrap_servers => "{{ monasca_kafka_servers }}"
+        topics => ["{{ monasca_transformed_logs_topic }}"]
+        group_id => "log_metrics"
+        consumer_threads => "{{ monasca_log_pipeline_threads }}"
+        codec => json
+    }
+}
+{% else %}
+{# Logstash 2 #}
 input {
     kafka {
         zk_connect => "{{ monasca_zookeeper_servers }}"
@@ -16,6 +28,7 @@ input {
         consumer_threads => "{{ monasca_log_pipeline_threads }}"
     }
 }
+{% endif %}
 
 filter {
     # Drop everything we don't want to create metrics for.
@@ -42,7 +55,12 @@ filter {
 
     # Convert the timestamp of the event to milliseconds since epoch.
     ruby {
+{% if monasca_logstash_use_v6 %}
+        code => "event.set('[metric][timestamp]', event.get('[@timestamp]').to_i*1000)"
+{% else %}
+{# Logstash 2 #}
         code => "event['metric']['timestamp'] = event['@timestamp'].to_i * 1000"
+{% endif %}
     }
 
     # Clean up any fields which aren't required from the new metric to save space
@@ -66,6 +84,16 @@ filter {
     }
 }
 
+{% if monasca_logstash_use_v6 %}
+output {
+    kafka {
+        codec => json
+        bootstrap_servers => "{{ monasca_kafka_servers }}"
+        topic_id => "{{ monasca_metrics_topic }}"
+    }
+}
+{% else %}
+{# Logstash 2 #}
 output {
     kafka {
         bootstrap_servers => "{{ monasca_kafka_servers }}"
@@ -74,3 +102,4 @@ output {
         workers => {{ monasca_log_pipeline_threads|int }}
     }
 }
+{% endif %}

--- a/ansible/roles/monasca/templates/monasca-log-metrics/monasca-log-metrics.json.j2
+++ b/ansible/roles/monasca/templates/monasca-log-metrics/monasca-log-metrics.json.j2
@@ -1,5 +1,6 @@
+{% set monasca_logstash_cmd = '/usr/share/logstash/bin/logstash --path.settings /etc/logstash/ --log.format json --path.logs /var/log/kolla/logstash/monasca-log-metrics' if monasca_logstash_use_v6 else '/opt/logstash/bin/logstash --log-in-json --log /var/log/kolla/logstash/monasca-log-metrics.log' %}
 {
-    "command": "/opt/logstash/bin/logstash --log-in-json --log /var/log/kolla/logstash/monasca-log-metrics.log -f /etc/logstash/conf.d/log-metrics.conf",
+    "command": "{{ monasca_logstash_cmd }} -f /etc/logstash/conf.d/log-metrics.conf",
     "config_files": [
         {
             "source": "{{ container_config_directory }}/log-metrics.conf",

--- a/ansible/roles/monasca/templates/monasca-log-persister/log-persister.conf.j2
+++ b/ansible/roles/monasca/templates/monasca-log-persister/log-persister.conf.j2
@@ -1,5 +1,17 @@
 # Persist transformed logs to Elasticsearch
 
+{% if monasca_logstash_use_v6 %}
+input {
+    kafka {
+        bootstrap_servers => "{{ monasca_kafka_servers }}"
+        topics => ["{{ monasca_transformed_logs_topic }}"]
+        group_id => "log_persister"
+        consumer_threads => "{{ monasca_log_pipeline_threads }}"
+        codec => json
+    }
+}
+{% else %}
+{# Logstash 2 #}
 input {
     kafka {
         zk_connect => "{{ monasca_zookeeper_servers }}"
@@ -9,6 +21,7 @@ input {
         consumer_threads => "{{ monasca_log_pipeline_threads }}"
     }
 }
+{% endif %}
 
 output {
     elasticsearch {

--- a/ansible/roles/monasca/templates/monasca-log-persister/monasca-log-persister.json.j2
+++ b/ansible/roles/monasca/templates/monasca-log-persister/monasca-log-persister.json.j2
@@ -1,5 +1,6 @@
+{% set monasca_logstash_cmd = '/usr/share/logstash/bin/logstash --path.settings /etc/logstash/ --log.format json --path.logs /var/log/kolla/logstash/monasca-log-persister' if monasca_logstash_use_v6 else '/opt/logstash/bin/logstash --log-in-json --log /var/log/kolla/logstash/monasca-log-persister.log' %}
 {
-    "command": "/opt/logstash/bin/logstash --log-in-json --log /var/log/kolla/logstash/monasca-log-persister.log -f /etc/logstash/conf.d/log-persister.conf",
+    "command": "{{ monasca_logstash_cmd }} -f /etc/logstash/conf.d/log-persister.conf",
     "config_files": [
         {
             "source": "{{ container_config_directory }}/log-persister.conf",

--- a/ansible/roles/monasca/templates/monasca-log-transformer/log-transformer.conf.j2
+++ b/ansible/roles/monasca/templates/monasca-log-transformer/log-transformer.conf.j2
@@ -1,6 +1,18 @@
 # Provide input/output streams for transforming Monasca logs.
 # Filters should be provided in other configuration files.
 
+{% if monasca_logstash_use_v6 %}
+input {
+    kafka {
+        bootstrap_servers => "{{ monasca_kafka_servers }}"
+        topics => ["{{ monasca_raw_logs_topic }}"]
+        group_id => "log_transformer"
+        consumer_threads => "{{ monasca_log_pipeline_threads }}"
+        codec => json
+    }
+}
+{% else %}
+{# Logstash 2 #}
 input {
     kafka {
         zk_connect => "{{ monasca_zookeeper_servers }}"
@@ -10,6 +22,7 @@ input {
         consumer_threads => "{{ monasca_log_pipeline_threads }}"
     }
 }
+{% endif %}
 
 filter {
     # Update the timestamp of the event based on the time in the message.
@@ -37,6 +50,16 @@ filter {
     }
 }
 
+{% if monasca_logstash_use_v6 %}
+output {
+    kafka {
+        codec => json
+        bootstrap_servers => "{{ monasca_kafka_servers }}"
+        topic_id => "{{ monasca_transformed_logs_topic }}"
+    }
+}
+{% else %}
+{# Logstash 2 #}
 output {
     kafka {
         bootstrap_servers => "{{ monasca_kafka_servers }}"
@@ -45,3 +68,4 @@ output {
         workers => {{ monasca_log_pipeline_threads|int }}
     }
 }
+{% endif %}

--- a/ansible/roles/monasca/templates/monasca-log-transformer/monasca-log-transformer.json.j2
+++ b/ansible/roles/monasca/templates/monasca-log-transformer/monasca-log-transformer.json.j2
@@ -1,5 +1,6 @@
+{% set monasca_logstash_cmd = '/usr/share/logstash/bin/logstash --path.settings /etc/logstash/ --log.format json --path.logs /var/log/kolla/logstash/monasca-log-transformer' if monasca_logstash_use_v6 else '/opt/logstash/bin/logstash --log-in-json --log /var/log/kolla/logstash/monasca-log-transformer.log' %}
 {
-    "command": "/opt/logstash/bin/logstash --log-in-json --log /var/log/kolla/logstash/monasca-log-transformer.log -f /etc/logstash/conf.d/log-transformer.conf",
+    "command": "{{ monasca_logstash_cmd }} -f /etc/logstash/conf.d/log-transformer.conf",
     "config_files": [
         {
             "source": "{{ container_config_directory }}/log-transformer.conf",

--- a/ansible/roles/neutron/defaults/main.yml
+++ b/ansible/roles/neutron/defaults/main.yml
@@ -35,7 +35,7 @@ neutron_services:
     host_in_groups: >-
       {{
       ( (inventory_hostname in groups['compute'] and nova_compute_virt_type != 'xenapi')
-      or (enable_manila | bool and inventory_hostname in groups['manila-share'])
+      or (enable_manila_backend_generic | bool and inventory_hostname in groups['manila-share'])
       or inventory_hostname in groups['neutron-dhcp-agent']
       or inventory_hostname in groups['neutron-l3-agent']
       or inventory_hostname in groups['neutron-metadata-agent']

--- a/ansible/roles/neutron/tasks/config.yml
+++ b/ansible/roles/neutron/tasks/config.yml
@@ -305,6 +305,7 @@
   register: neutron_policy
 
 - name: Copying over nsx.ini
+  become: true
   vars:
     service_name: "neutron-server"
     neutron_server: "{{ neutron_services[service_name] }}"

--- a/ansible/roles/nova-cell/defaults/main.yml
+++ b/ansible/roles/nova-cell/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-project_name: "nova-cell"
+project_name: "nova"
 
 nova_cell_services:
   nova-libvirt:

--- a/ansible/roles/nova/tasks/bootstrap.yml
+++ b/ansible/roles/nova/tasks/bootstrap.yml
@@ -46,6 +46,9 @@
 
 - import_tasks: config_bootstrap.yml
 
+- include_tasks: clone.yml
+  when: nova_dev_mode | bool
+
 - import_tasks: bootstrap_service.yml
 
 - import_tasks: map_cell0.yml

--- a/ansible/roles/nova/tasks/deploy.yml
+++ b/ansible/roles/nova/tasks/deploy.yml
@@ -2,9 +2,6 @@
 - include_tasks: register.yml
   when: inventory_hostname in groups['nova-api']
 
-- include_tasks: clone.yml
-  when: nova_dev_mode | bool
-
 - include_tasks: config.yml
 
 - name: Flush handlers

--- a/ansible/roles/octavia/defaults/main.yml
+++ b/ansible/roles/octavia/defaults/main.yml
@@ -123,6 +123,10 @@ octavia_logging_debug: "{{ openstack_logging_debug }}"
 
 octavia_keystone_user: "octavia"
 
+# Project that Octavia will use to interact with other services.  Note that in
+# Ussuri and later releases this will change to "service".
+octavia_service_auth_project: "admin"
+
 openstack_octavia_auth: "{{ openstack_auth }}"
 
 ####################

--- a/ansible/roles/octavia/tasks/register.yml
+++ b/ansible/roles/octavia/tasks/register.yml
@@ -7,6 +7,20 @@
     service_ks_register_users: "{{ octavia_ks_users }}"
   tags: always
 
+- name: "Adding admin role to octavia user in {{ octavia_service_auth_project }} project"
+  become: true
+  kolla_toolbox:
+    module_name: "os_user_role"
+    module_args:
+      user: "{{ octavia_keystone_user }}"
+      role: admin
+      project: "{{ octavia_service_auth_project }}"
+      auth: "{{ openstack_octavia_auth }}"
+      endpoint_type: "{{ openstack_interface }}"
+      cacert: "{{ openstack_cacert }}"
+  run_once: True
+  when: octavia_service_auth_project != 'service'
+
 - name: Adding octavia related roles
   become: true
   kolla_toolbox:

--- a/ansible/roles/octavia/templates/octavia.conf.j2
+++ b/ansible/roles/octavia/templates/octavia.conf.j2
@@ -32,7 +32,7 @@ auth_type = password
 username = {{ octavia_keystone_user }}
 password = {{ octavia_keystone_password }}
 user_domain_name = {{ default_user_domain_name }}
-project_name = {{ openstack_auth.project_name }}
+project_name = {{ octavia_service_auth_project }}
 project_domain_name = {{ default_project_domain_name }}
 
 memcache_security_strategy = ENCRYPT

--- a/ansible/roles/openvswitch/defaults/main.yml
+++ b/ansible/roles/openvswitch/defaults/main.yml
@@ -10,7 +10,7 @@ openvswitch_services:
     host_in_groups: >-
       {{
       inventory_hostname in groups['compute']
-      or (enable_manila | bool and inventory_hostname in groups['manila-share'])
+      or (enable_manila_backend_generic | bool and inventory_hostname in groups['manila-share'])
       or inventory_hostname in groups['neutron-dhcp-agent']
       or inventory_hostname in groups['neutron-l3-agent']
       or inventory_hostname in groups['neutron-metadata-agent']
@@ -25,7 +25,7 @@ openvswitch_services:
     host_in_groups: >-
       {{
       inventory_hostname in groups['compute']
-      or (enable_manila | bool and inventory_hostname in groups['manila-share'])
+      or (enable_manila_backend_generic | bool and inventory_hostname in groups['manila-share'])
       or inventory_hostname in groups['neutron-dhcp-agent']
       or inventory_hostname in groups['neutron-l3-agent']
       or inventory_hostname in groups['neutron-metadata-agent']

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -79,6 +79,7 @@
         - enable_senlin_{{ enable_senlin | bool }}
         - enable_skydive_{{ enable_skydive | bool }}
         - enable_solum_{{ enable_solum | bool }}
+        - enable_storm_{{ enable_storm | bool }}
         - enable_swift_{{ enable_swift | bool }}
         - enable_tacker_{{ enable_tacker | bool }}
         - enable_telegraf_{{ enable_telegraf | bool }}
@@ -631,6 +632,7 @@
   hosts:
     - storm-worker
     - storm-nimbus
+    - '&enable_storm_True'
   serial: '{{ kolla_serial|default("0") }}'
   roles:
     - { role: storm,

--- a/doc/source/admin/mariadb-backup-and-restore.rst
+++ b/doc/source/admin/mariadb-backup-and-restore.rst
@@ -88,8 +88,8 @@ following options on the master database node:
    (dbrestore) $ cd /backup
    (dbrestore) $ rm -rf /backup/restore
    (dbrestore) $ mkdir -p /backup/restore/full
-   (dbrestore) $ gunzip mysqlbackup-04-10-2018.xbc.xbs.gz
-   (dbrestore) $ mbstream -x -C /backup/restore/full/ < mysqlbackup-04-10-2018.xbc.xbs
+   (dbrestore) $ gunzip mysqlbackup-04-10-2018.qp.xbc.xbs.gz
+   (dbrestore) $ mbstream -x -C /backup/restore/full/ < mysqlbackup-04-10-2018.qp.xbc.xbs
    (dbrestore) $ mariabackup --prepare --target-dir /backup/restore/full
 
 Stop the MariaDB instance.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -106,6 +106,7 @@ openstack_projects = [
     'neutron-vpnaas',
     'neutron',
     'nova',
+    'octavia',
     'oslotest',
     'swift',
 ]

--- a/doc/source/contributor/vagrant-dev-env.rst
+++ b/doc/source/contributor/vagrant-dev-env.rst
@@ -40,13 +40,20 @@ choice. Various downloads can be found at the `Vagrant downloads
 
 Install required dependencies as follows:
 
-For CentOS 7 or later:
+For CentOS or RHEL 7:
 
 .. code-block:: console
 
    sudo yum install ruby-devel libvirt-devel zlib-devel libpng-devel gcc \
    qemu-kvm qemu-img libvirt libvirt-python libvirt-client virt-install \
    bridge-utils git
+
+For CentOS or RHEL 8:
+
+.. code-block:: console
+
+   sudo dnf install ruby-devel libvirt-devel zlib-devel libpng-devel gcc \
+   qemu-kvm qemu-img libvirt python3-libvirt libvirt-client virt-install git
 
 For Ubuntu 16.04 or later:
 

--- a/doc/source/reference/networking/index.rst
+++ b/doc/source/reference/networking/index.rst
@@ -14,6 +14,7 @@ Networking-SFC, QoS, and so on.
    dpdk
    neutron
    neutron-extensions
+   octavia
    opendaylight
    provider-networks
    sriov

--- a/doc/source/reference/networking/octavia.rst
+++ b/doc/source/reference/networking/octavia.rst
@@ -1,0 +1,197 @@
+=======
+Octavia
+=======
+
+Octavia provides load balancing as a service. This guide covers configuration
+of Octavia for the Amphora driver. See the :octavia-doc:`Octavia documentation
+<>` for full details.
+
+Resources
+=========
+
+Currently in Kolla Ansible it is necessary to manually register the OpenStack
+resources required by Octavia. Kolla Ansible aims to automate this in the
+future.
+
+.. note::
+
+   In Ussuri and later releases, resources are registered in the ``service``
+   project. This is configured via ``octavia_service_auth_project``,
+   and may be set to ``service`` to avoid a breaking change when upgrading to
+   Ussuri. Changing the project on an existing system requires at a minimum
+   registering a new security group in the new project. Ideally the flavor and
+   network should be recreated in the new project, although this will impact
+   existing Amphorae.
+
+All resources should be registered in the ``admin`` project. This can be done
+as follows:
+
+.. code-block:: console
+
+   source admin-openrc.sh
+   export OS_USERNAME=octavia
+   export OS_PASSWORD=<octavia keystone password>
+   export OS_PROJECT_NAME=admin
+   export OS_TENANT_NAME=admin
+
+You can find the Octavia password in ``passwords.yml``.
+
+Amphora image
+-------------
+
+It is necessary to build an Amphora image. On CentOS / RHEL 8:
+
+.. code-block:: console
+
+   sudo dnf -y install epel-release
+   sudo dnf install -y debootstrap
+
+On Ubuntu:
+
+.. code-block:: console
+
+   sudo apt -y install debootstrap
+
+Acquire the Octavia source code:
+
+.. code-block:: console
+
+   git clone https://opendev.org/openstack/octavia -b <branch>
+
+Install ``diskimage-builder``, ideally in a virtual environment:
+
+.. code-block:: console
+
+   python3 -m venv dib-venv
+   source dib-venv/bin/activate
+   pip install diskimage-builder
+
+Create the Amphora image:
+
+.. code-block:: console
+
+   cd octavia/diskimage-create
+   ./diskimage-create.sh
+
+Register the image in Glance:
+
+.. code-block:: console
+
+   openstack image create amphora-x64-haproxy.qcow2 --container-format bare --disk-format qcow2 --private --tag amphora --file amphora-x64-haproxy.qcow2
+
+Octavia uses the tag to determine which image to use.
+
+Amphora flavor
+--------------
+
+Register the flavor in Nova:
+
+.. code-block:: console
+
+   openstack flavor create --vcpus 1 --ram 1024 --disk 2 "amphora" --private
+
+Make a note of the ID of the flavor, or specify one via ``--id``.
+
+Keypair
+-------
+
+Register the keypair in Nova:
+
+.. code-block:: console
+
+   openstack keypair create --public-key <path to octavia public key> octavia_ssh_key
+
+Network and subnet
+------------------
+
+Register the management network and subnet in Neutron. This must be a network
+that is accessible from the controllers. Typically a VLAN provider network is
+used. In that case it will be necessary to enable Neutron provider networks.
+
+.. code-block:: console
+
+   OCTAVIA_MGMT_SUBNET=192.168.43.0/24
+   OCTAVIA_MGMT_SUBNET_START=192.168.43.10
+   OCTAVIA_MGMT_SUBNET_END=192.168.43.254
+
+   openstack network create lb-mgmt-net --provider-network-type vlan --provider-segment 107  --provider-physical-network physnet1
+   openstack subnet create --subnet-range $OCTAVIA_MGMT_SUBNET --allocation-pool \
+     start=$OCTAVIA_MGMT_SUBNET_START,end=$OCTAVIA_MGMT_SUBNET_END \
+     --network lb-mgmt-net lb-mgmt-subnet
+
+Make a note of the ID of the network.
+
+Security group
+--------------
+
+Register the security group in Neutron.
+
+.. code-block:: console
+
+   openstack security group create lb-mgmt-sec-grp
+   openstack security group rule create --protocol icmp lb-mgmt-sec-grp
+   openstack security group rule create --protocol tcp --dst-port 22 lb-mgmt-sec-grp
+   openstack security group rule create --protocol tcp --dst-port 9443 lb-mgmt-sec-grp
+
+Make a note of the ID of the security group.
+
+Kolla Ansible configuration
+===========================
+
+Globals
+-------
+
+The following options should be added to ``globals.yml``.
+
+Enable the Octavia service:
+
+.. code-block:: yaml
+
+   enable_octavia: yes
+
+If using a VLAN for the Octavia management network, enable Neutron provider
+networks:
+
+.. code-block:: yaml
+
+   enable_neutron_provider_networks: yes
+
+Configure the name of the network interface on the controllers used to access
+the Octavia management network. If using a VLAN provider network, ensure that
+the traffic is also bridged to Open vSwitch on the controllers.
+
+.. code-block:: yaml
+
+   octavia_network_interface: <network interface on controllers>
+
+Set the IDs of the resources registered previously:
+
+.. code-block:: yaml
+
+   octavia_amp_boot_network_list: <ID of lb-mgmt-net>
+   octavia_amp_secgroup_list: <ID of lb-mgmt-sec-grp>
+   octavia_amp_flavor_id: <ID of amphora flavor>
+
+Passwords
+---------
+
+The following option should be set in ``passwords.yml``, matching the password
+used to encrypt the CA key:
+
+.. code-block:: yaml
+
+   octavia_ca_password: <CA key password>
+
+Certificates
+============
+
+Follow the :octavia-doc:`octavia documentation
+<admin/guides/certificates.html>` to generate certificates for Amphorae. These
+should be copied to the Kolla Ansible configuration as follows:
+
+.. code-block:: ini
+
+   cp client_ca/certs/ca.cert.pem /etc/kolla/config/octavia/client_ca.cert.pem
+   cp server_ca/certs/ca.cert.pem /etc/kolla/config/octavia/server_ca.cert.pem
+   cp server_ca/private/ca.key.pem /etc/kolla/config/octavia/server_ca.key.pem
+   cp client_ca/private/client.cert-and-key.pem /etc/kolla/config/octavia/client.cert-and-key.pem

--- a/doc/source/user/quickstart.rst
+++ b/doc/source/user/quickstart.rst
@@ -45,11 +45,17 @@ execution, which is described in
 
 #. Install Python build dependencies:
 
-   For CentOS or RHEL, run:
+   For CentOS or RHEL 7, run:
 
    .. code-block:: console
 
       sudo yum install python-devel libffi-devel gcc openssl-devel libselinux-python
+
+   For CentOS or RHEL 8, run:
+
+   .. code-block:: console
+
+      sudo dnf install python3-devel libffi-devel gcc openssl-devel python3-libselinux
 
    For Ubuntu, run:
 
@@ -64,11 +70,17 @@ If not installing Kolla Ansible in a virtual environment, skip this section.
 
 #. Install the virtualenv package.
 
-   For CentOS or RHEL, run:
+   For CentOS or RHEL 7, run:
 
    .. code-block:: console
 
       sudo yum install python-virtualenv
+
+   For CentOS or RHEL 8, run:
+
+   .. code-block:: console
+
+      sudo dnf install python3-virtualenv
 
    For Ubuntu, run:
 

--- a/etc/kolla/globals.yml
+++ b/etc/kolla/globals.yml
@@ -362,7 +362,7 @@
 #enable_vitrage: "no"
 #enable_vmtp: "no"
 #enable_watcher: "no"
-#enable_zookeeper: "{{ enable_kafka | bool }}"
+#enable_zookeeper: "{{ enable_kafka | bool or enable_storm | bool }}"
 #enable_zun: "no"
 
 ##################

--- a/kolla_ansible/cmd/genpwd.py
+++ b/kolla_ansible/cmd/genpwd.py
@@ -59,6 +59,10 @@ def genpwd(passwords_file, length, uuid_keys, ssh_keys, blank_keys,
     with open(passwords_file, 'r') as f:
         passwords = yaml.safe_load(f.read())
 
+    if not isinstance(passwords, dict):
+        print("ERROR: Passwords file not in expected key/value format")
+        sys.exit(1)
+
     for k, v in passwords.items():
         if (k in ssh_keys and
                 (v is None

--- a/kolla_ansible/cmd/mergepwd.py
+++ b/kolla_ansible/cmd/mergepwd.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import argparse
+import sys
 import yaml
 
 
@@ -22,6 +23,14 @@ def mergepwd(old, new, final):
 
     with open(new, "r") as new_file:
         new_passwords = yaml.safe_load(new_file)
+
+    if not isinstance(old_passwords, dict):
+        print("ERROR: Old passwords file not in expected key/value format")
+        sys.exit(1)
+
+    if not isinstance(new_passwords, dict):
+        print("ERROR: New passwords file not in expected key/value format")
+        sys.exit(1)
 
     new_passwords.update(old_passwords)
 

--- a/releasenotes/notes/bug-1881890-72c76f5fc065588b.yaml
+++ b/releasenotes/notes/bug-1881890-72c76f5fc065588b.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes Grafana datasource update.
+    `LP#1881890 <https://launchpad.net/bugs/1881890>`__

--- a/releasenotes/notes/bug-1882513-chrony-permission-denied-917b3bffc5cdb38d.yaml
+++ b/releasenotes/notes/bug-1882513-chrony-permission-denied-917b3bffc5cdb38d.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Removing chrony package and AppArmor profile from docker host if
+    containerized chrony is enabled.
+    `LP#1882513 <https://bugs.launchpad.net/kolla-ansible/+bug/1882513>`__

--- a/releasenotes/notes/bug-1884939-7c77b8002d3ff52d.yaml
+++ b/releasenotes/notes/bug-1884939-7c77b8002d3ff52d.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes an issue with Manila deployment starting ``openvswitch`` and
+    ``neutron-openvswitch-agent`` containers when
+    ``enable_manila_backend_generic`` was set to ``False``.
+    `LP#1884939 <https://bugs.launchpad.net/kolla-ansible/+bug/1884939>`__

--- a/releasenotes/notes/bug-missing-become-attributes-vmware-9ae97e49b4d7dc0d.yaml
+++ b/releasenotes/notes/bug-missing-become-attributes-vmware-9ae97e49b4d7dc0d.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Add missing "become: true" on some VMWare related tasks. Fixed on
+    ``Copying VMware vCenter CA file`` and ``Copying over nsx.ini``.

--- a/releasenotes/notes/bug-nova-dev-mod-failed-ad4e64f5a5bc2a6a.yaml
+++ b/releasenotes/notes/bug-nova-dev-mod-failed-ad4e64f5a5bc2a6a.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    fix deploy nova failed when use kolla_dev_mod.

--- a/releasenotes/notes/clients-in-magnum-use-internalURL-af3ad82af71a88c6.yaml
+++ b/releasenotes/notes/clients-in-magnum-use-internalURL-af3ad82af71a88c6.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    In line with clients for other services used by Magnum, it now uses
+    endpoint_type = internalURL also for Magnum itself, Cinder and Octavia
+    clients. In the same tune, these services also use the globally defined
+    `openstack_region_name`.

--- a/releasenotes/notes/elasticsearch-kibana-6-6621548e948d9d23.yaml
+++ b/releasenotes/notes/elasticsearch-kibana-6-6621548e948d9d23.yaml
@@ -1,0 +1,10 @@
+---
+upgrade:
+  - |
+    Adds ``elasticsearch_use_v6`` and ``kibana_use_v6`` flags which can be set
+    to ``true`` to deploy the ``elasticsearch6`` and ``kibana6`` images on
+    CentOS 7 or 8. These flags are ``true`` by default on CentOS 8, and
+    ``false`` elsewhere. The services should be upgraded from 5.x to 6.x via
+    ``kolla-ansible upgrade elasticsearch,kibana``, and this can be used to
+    provide an Elasticsearch 6.x cluster that is compatible between CentOS 7
+    and 8.

--- a/releasenotes/notes/fix-cinder-upgrade-max-count-ab928f85f224c63d.yaml
+++ b/releasenotes/notes/fix-cinder-upgrade-max-count-ab928f85f224c63d.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes an issue with Cinder upgrades that would cause online schema
+    migration to fail. `LP#1880753 <https://launchpad.net/bugs/1880753>`__

--- a/releasenotes/notes/fix-octavia-service-auth-project-849a4e5bd852e9c7.yaml
+++ b/releasenotes/notes/fix-octavia-service-auth-project-849a4e5bd852e9c7.yaml
@@ -1,0 +1,40 @@
+---
+fixes:
+  - |
+    In the previous stable release, the octavia user was no longer given the
+    admin role in the admin project, and a task was added to remove the role
+    during upgrades. However, the octavia configuration was not updated to use
+    the service project, causing load balancer creation to fail. See upgrade
+    notes for details.  `LP#1873176
+    <https://bugs.launchpad.net/kolla-ansible/+bug/1873176>`__
+upgrade:
+  - |
+    In the previous stable release, the octavia user was no longer given the
+    admin role in the admin project, and a task was added to remove the role
+    during upgrades. However, the octavia configuration was not updated to use
+    the service project, causing load balancer creation to fail.
+
+    There is also an issue for existing deployments in simply switching to the
+    service project. While existing load balancers appear to continue to work,
+    creating new load balancers fails due to the security group belonging to
+    the admin project. For this reason, Train and Stein have been reverted to
+    use the admin project by default, while from the Ussuri release the service
+    project will be used by default.
+
+    To provide flexibility, an ``octavia_service_auth_project`` variable has
+    been added. In the Train and Stein releases this is set to ``admin`` by
+    default, and from Ussuri it will be set to ``service`` by default.
+    For users of Train and Stein, ``octavia_service_auth_project`` may be set
+    to ``service`` in order to avoid a breaking change during the Ussuri
+    upgrade.
+
+    To switch an existing deployment from using the ``admin`` project to the
+    ``service`` project, it will at least be necessary to create the required
+    security group in the ``service`` project, and update
+    ``octavia_amp_secgroup_list`` to this group's ID. Ideally the Amphora
+    flavor and network would also be recreated in the ``service`` project,
+    although this does not appear to be necessary for operation, and will
+    impact existing Amphorae.
+
+    See `bug 1873176 <https://bugs.launchpad.net/kolla-ansible/+bug/1873176>`__
+    for details.

--- a/releasenotes/notes/fluentd-elasticsearch-cacert-0e8824dd57052913.yaml
+++ b/releasenotes/notes/fluentd-elasticsearch-cacert-0e8824dd57052913.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Adds a new variable ``fluentd_elasticsearch_cacert``, which defaults to the
+    value of ``openstack_cacert``. If set, this will be used to set the path of
+    the CA certificate bundle used by Fluentd when communicating with
+    Elasticsearch. `LP#1885109
+    <https://bugs.launchpad.net/kolla-ansible/+bug/1885109>`__

--- a/releasenotes/notes/improve-pwd-errors-7563a3cc941c3091.yaml
+++ b/releasenotes/notes/improve-pwd-errors-7563a3cc941c3091.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Improves error reporting in ``kolla-genpwd`` and ``kolla-mergepwd`` when
+    input files are not in the expected format. `LP#1880220
+    <https://bugs.launchpad.net/kolla-ansible/+bug/1880220>`__.

--- a/releasenotes/notes/kibana-tls-verify-8bfcb822268ad0d8.yaml
+++ b/releasenotes/notes/kibana-tls-verify-8bfcb822268ad0d8.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    Changes the default value of ``kibana_elasticsearch_ssl_verify`` from
+    ``false`` to ``true``. `LP#1885110
+    <https://bugs.launchpad.net/kolla-ansible/+bug/1885110>`__

--- a/releasenotes/notes/magnum-trustee-keystone-region-name-002162a45f855faf.yaml
+++ b/releasenotes/notes/magnum-trustee-keystone-region-name-002162a45f855faf.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes Magnum trust operations in multi-region deployments.

--- a/releasenotes/notes/storm-enable-zookeeper-2108156acced1c57.yaml
+++ b/releasenotes/notes/storm-enable-zookeeper-2108156acced1c57.yaml
@@ -1,0 +1,10 @@
+---
+upgrade:
+  - |
+    Apache ZooKeeper will now be automatically deployed whenever Apache Storm
+    is enabled.
+fixes:
+  - |
+    Deploys Apache ZooKeeper if Apache Storm is enabled explicitly. ZooKeeper
+    would only be deployed if Apache Kafka was also enabled, which is often
+    done implicitly by enabling Monasca.

--- a/releasenotes/notes/support-logstash-6-d64bb51217b79a77.yaml
+++ b/releasenotes/notes/support-logstash-6-d64bb51217b79a77.yaml
@@ -1,0 +1,12 @@
+---
+upgrade:
+  - |
+    When deploying Monasca with Logstash 6 (the default for Centos 8), any
+    custom Logstash 2 configuration for Monasca will need to be updated to
+    work with Logstash 6. Please consult the `documentation
+    <https://www.elastic.co/guide/en/logstash/master/upgrading-logstash.html>`__.
+fixes:
+  - |
+    When deploying Elasticsearch 6 (the default for Centos 8), Logstash 2 was
+    deployed by default which is not compatible with Elasticsearch 6. Logstash
+    6 is now deployed by default when using Centos 8 containers.

--- a/tests/pre.yml
+++ b/tests/pre.yml
@@ -15,11 +15,59 @@
         fail_msg: >-
           The nodepool private IP address {{ nodepool.private_ipv4 }} is not assigned
 
-    - name: Install dbus for debian system
-      apt: name=dbus
-      when:
-        - ansible_os_family == 'Debian'
+    - block:
+        # NOTE(mgoddard): The CentOS image used in CI has epel-release installed,
+        # but the configure-mirrors role used by Zuul disables epel. Since we
+        # install epel-release and expect epel to be enabled, enable it here.
+        - name: Ensure yum-utils is installed
+          package:
+            name: yum-utils
+            state: present
+
+        - name: Enable the EPEL repository
+          command: yum-config-manager --enable epel
       become: true
+      when:
+        - ansible_os_family == "RedHat"
+        - ansible_distribution_major_version | int == 7
+
+    - name: Install Python2 modules
+      become: true
+      package:
+        name:
+          - python-pip
+          - python-setuptools
+          - python-virtualenv
+          - python-wheel
+      when:
+        - not (ansible_os_family == "RedHat" and ansible_distribution_major_version | int == 8)
+
+    # NOTE(hrw): On RedHat systems it is part of python3-virtualenv
+    - name: Install virtualenv on Debian systems
+      package:
+        name:
+          - virtualenv
+      become: true
+      when:
+        ansible_os_family == "Debian"
+
+    - name: Install Python3 modules on CentOS 8 systems
+      become: true
+      package:
+        name:
+          - python3-pip
+          - python3-setuptools
+          - python3-virtualenv
+          - python3-wheel
+      when:
+        - ansible_os_family == "RedHat"
+        - ansible_distribution_major_version | int == 8
+
+    - name: Ensure latest pip is installed
+      become: true
+      pip:
+        name: pip
+        state: latest
 
     - name: Ensure /tmp/logs/ dir
       file:

--- a/tests/run.yml
+++ b/tests/run.yml
@@ -53,6 +53,7 @@
     - name: Ensure tox is installed
       pip:
         name: tox
+        virtualenv: "{{ ansible_env.HOME }}/tox-venv"
       when: need_build_image
       become: true
 
@@ -251,6 +252,7 @@
         TAG: "{{ build_image_tag }}"
         KOLLA_SRC_DIR: "{{ ansible_env.HOME }}/src/opendev.org/openstack/kolla"
         SCENARIO: "{{ scenario }}"
+        TOX_VENV: "{{ ansible_env.HOME }}/tox-venv"
         UPPER_CONSTRAINTS: "{{ ansible_env.HOME }}/src/opendev.org/openstack/requirements/upper-constraints.txt"
 
     - name: Run init-swift.sh script

--- a/tests/test-scenario-nfv.sh
+++ b/tests/test-scenario-nfv.sh
@@ -48,16 +48,10 @@ function test_heat {
     openstack stack list
 }
 
-function install_requirements {
-    echo "TESTING: Install requirements"
-    pip install "python-tackerclient" "python-heatclient" "networking-sfc" "python-mistralclient" "python-barbicanclient"
-}
-
 function test_scenario_nfv_logged {
     . /etc/kolla/admin-openrc.sh
     . ~/openstackclient-venv/bin/activate
 
-    install_requirements
     test_tacker
     test_barbican
     test_mistral

--- a/tools/init-runonce
+++ b/tools/init-runonce
@@ -103,7 +103,7 @@ openstack security group rule create --ingress --ethertype IPv4 \
 
 if [ ! -f ~/.ssh/id_rsa.pub ]; then
     echo Generating ssh key.
-    ssh-keygen -t rsa -f ~/.ssh/id_rsa
+    ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa
 fi
 if [ -r ~/.ssh/id_rsa.pub ]; then
     echo Configuring nova public key and quotas.

--- a/tools/setup_gate.sh
+++ b/tools/setup_gate.sh
@@ -20,6 +20,9 @@ function setup_openstack_clients {
     if [[ $SCENARIO == masakari ]]; then
         packages+=(python-masakariclient)
     fi
+    if [[ $SCENARIO == scenario_nfv ]]; then
+        packages+=(python-tackerclient python-barbicanclient python-mistralclient)
+    fi
     virtualenv ~/openstackclient-venv
     ~/openstackclient-venv/bin/pip install -U pip
     ~/openstackclient-venv/bin/pip install -c $UPPER_CONSTRAINTS ${packages[@]}
@@ -99,7 +102,7 @@ function prepare_images {
     else
         kolla_base_distro=${BASE_DISTRO}
     fi
-    sudo tox -e "build-${kolla_base_distro}-${INSTALL_TYPE}"
+    sudo $TOX_VENV/bin/tox -e "build-${kolla_base_distro}-${INSTALL_TYPE}"
     # NOTE(yoctozepto): due to debian buster we push after images are built
     # see https://github.com/docker/for-linux/issues/711
     if [[ "debian" == $BASE_DISTRO ]]; then

--- a/zuul.d/base.yaml
+++ b/zuul.d/base.yaml
@@ -103,3 +103,25 @@
       - ^tests/test-swift.sh
     vars:
       scenario: swift
+
+- job:
+    name: kolla-ansible-masakari-base
+    parent: kolla-ansible-base
+    voting: false
+    files:
+      - ^ansible/roles/masakari/
+      - ^tests/test-masakari.sh
+      - ^tests/test-dashboard.sh
+    vars:
+      scenario: masakari
+
+- job:
+    name: kolla-ansible-scenario-nfv-base
+    parent: kolla-ansible-base
+    voting: false
+    files:
+      - ^ansible/roles/(barbican|heat|mistral|redis|tacker)/
+      - ^tests/test-scenario-nfv.sh
+      - ^tests/test-dashboard.sh
+    vars:
+      scenario: scenario_nfv

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -103,13 +103,14 @@
         - kolla-ansible-centos8-source-masakari
         - kolla-ansible-ubuntu-source-masakari
         - kolla-ansible-centos-source-masakari
+        - kolla-ansible-centos8-source-scenario-nfv
         - kolla-ansible-centos-source-scenario-nfv
         - kolla-ansible-centos8-source-ironic
+        - kolla-ansible-centos8-binary-ironic
         - kolla-ansible-centos-source-ironic
         - kolla-ansible-centos-binary-ironic
         - kolla-ansible-ubuntu-source-ironic
         - kolla-ansible-centos-source-upgrade
-        - kolla-ansible-centos8-source-upgrade
         - kolla-ansible-ubuntu-source-upgrade
         - kolla-ansible-centos-source-upgrade-ceph
         - kolla-ansible-ubuntu-source-upgrade-ceph


### PR DESCRIPTION
When using Centos8 with the Train release only Elasticsearch 6 is provided.
Whilst the Logstash 2 image builds for Centos8, we upgrade it inline with
Elasticsearch to avoid compatibility problems [1].

[1] https://www.elastic.co/support/matrix#matrix_compatibility

Depends-On: https://review.opendev.org/#/c/736745/
Change-Id: I820dea961e270de9eabb9cc3c75303f5170ce737
Partial-Bug: #1884090
(cherry picked from commit f38bc84214fdb3f274ac9bcc000a3ace0bcbc8f4)