### PR TITLE
Set a chunk size for Fluentd bulk log upload to Monasca

### DIFF
--- a/ansible/roles/common/templates/conf/output/00-local.conf.j2
+++ b/ansible/roles/common/templates/conf/output/00-local.conf.j2
@@ -50,6 +50,9 @@
        buffer_path /var/lib/fluentd/data/monasca.buffer/{{ syslog_swift_facility }}.*
        max_retry_wait 1800s
        disable_retry_limit true
+       <buffer>
+         chunk_limit_size 8m
+       </buffer>
     </store>
 {% endif %}
 </match>
@@ -108,6 +111,9 @@
        buffer_path /var/lib/fluentd/data/monasca.buffer/{{ syslog_haproxy_facility }}.*
        max_retry_wait 1800s
        disable_retry_limit true
+       <buffer>
+         chunk_limit_size 8m
+       </buffer>
     </store>
 {% endif %}
 </match>

--- a/ansible/roles/common/templates/conf/output/02-monasca.conf.j2
+++ b/ansible/roles/common/templates/conf/output/02-monasca.conf.j2
@@ -14,5 +14,8 @@
        buffer_path /var/lib/fluentd/data/monasca.buffer/openstack.*
        max_retry_wait 1800s
        disable_retry_limit true
+       <buffer>
+         chunk_limit_size 8m
+       </buffer>
     </store>
 </match>

--- a/releasenotes/notes/fix-fluentd-buffer-chunk-size-for-monasca-output-882338103d2e1f13.yaml
+++ b/releasenotes/notes/fix-fluentd-buffer-chunk-size-for-monasca-output-882338103d2e1f13.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixes `LP#1885885
+    <https://bugs.launchpad.net/kolla-ansible/+bug/1885885>`__ where the
+    default chunk size in the Monasca Fluentd output plugin increased from
+    8MB to 256MB for file buffering which exceeded the limit allowed by
+    the Monasca Log / Unified API.


### PR DESCRIPTION
In Fluentd v0.12, both the in memory and file buffer chunk size default
to 8MB. In v1.0 the file buffer defaults to 256MB. This can exceed the
Monasca Log or Unified API maximum chunk size which is set to 10MB.
This can result in logs being rejected and filling the local buffer
on disk.

Change-Id: I9c495773db726a3c5cd94b819dff4141737a1d6e
Closes-Bug: #1885885
Co-Authored-By: Sebastian Luna Valero <sebastian.luna.valero@gmail.com>
(cherry picked from commit 2c919bc61ca7a903e93372604fa0e770f95b0d52)