### PR TITLE
Use kolla_logs volume for Elasticsearch

### DIFF
--- a/ansible/roles/elasticsearch/defaults/main.yml
+++ b/ansible/roles/elasticsearch/defaults/main.yml
@@ -11,6 +11,7 @@ elasticsearch_services:
       - "{{ node_config_directory }}/elasticsearch/:{{ container_config_directory }}/"
       - "/etc/localtime:/etc/localtime:ro"
       - "elasticsearch:/var/lib/elasticsearch/data"
+      - "kolla_logs:/var/log/kolla/"
     dimensions: "{{ elasticsearch_dimensions }}"
   elasticsearch-curator:
     container_name: elasticsearch_curator


### PR DESCRIPTION
This patch mounts the kolla_logs volume into the Elasticsearch
container so that logs are no longer written to the container
filesystem. It is up to the user to migrate any existing logs
into the kolla_logs volume, if they so desire.

Closes-Bug: #1859162
Change-Id: Ia1743e202e310fc88a61476c80eadf3855256c20