### PR TITLE
Fix the Elasticsearch Curator cron schedule run

### DIFF
--- a/ansible/roles/elasticsearch/templates/elasticsearch-curator.crontab.j2
+++ b/ansible/roles/elasticsearch/templates/elasticsearch-curator.crontab.j2
@@ -1,1 +1,3 @@
+PATH=/usr/local/bin:/usr/bin:/bin
+
 {{ elasticsearch_curator_cron_schedule }} curator --config /etc/elasticsearch-curator/curator.yml {% if elasticsearch_curator_dry_run|bool %}--dry-run {% endif %}/etc/elasticsearch-curator/actions.yml

--- a/ansible/roles/elasticsearch/templates/elasticsearch-curator.json.j2
+++ b/ansible/roles/elasticsearch/templates/elasticsearch-curator.json.j2
@@ -1,11 +1,12 @@
 {% set cron_cmd = 'cron -f' if kolla_base_distro in ['ubuntu', 'debian'] else 'crond -s -n' %}
+{% set cron_path = '/var/spool/cron/crontabs/elasticsearch' if kolla_base_distro in ['ubuntu', 'debian'] else '/var/spool/cron/elasticsearch' %}
 {
     "command": "{{ cron_cmd }}",
     "config_files": [
         {
             "source": "{{ container_config_directory }}/elasticsearch-curator.crontab",
-            "dest": "/var/spool/cron/elasticsearch",
-            "owner": "root",
+            "dest": "{{ cron_path }}",
+            "owner": "elasticsearch",
             "perm": "0600"
         },
         {

--- a/releasenotes/notes/bug-1885732-10803d46f9c73444.yaml
+++ b/releasenotes/notes/bug-1885732-10803d46f9c73444.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes the Elasticsearch Curator cron schedule run.
+    `LP#1885732 <https://launchpad.net/bugs/1885732>`__


### PR DESCRIPTION
There were two issues with it. Lack of /usr/local/bin in PATH
for CentOS and wrong crontab path for Ubuntu/Debian.
This patch mirrors how it is handled in keystone.

Change-Id: Ib54b261e12c409d66b792648807646015826e83c
Closes-Bug: #1885732
(cherry picked from commit 852c7a32c3a00d88243ef3b89ce19e6391a676b1)