### PR TITLE
Make ES Curator schedule multinode-friendly

### DIFF
--- a/ansible/roles/elasticsearch/defaults/main.yml
+++ b/ansible/roles/elasticsearch/defaults/main.yml
@@ -36,10 +36,18 @@ es_java_opts: "{% if es_heap_size %}-Xms{{ es_heap_size }} -Xmx{{ es_heap_size }
 # Elasticsearch Curator
 #######################
 
-# How frequently Curator runs. On multinode deployments of Curator
-# you may wish to override this in hostvars so that Curator does
-# not run simultaneously on all nodes. Defaults to every midnight.
-elasticsearch_curator_cron_schedule: "0 0 * * *"
+# Helper variable used to define the default hour Curator runs to avoid
+# simultaneous runs in multinode deployments.
+elasticsearch_curator_instance_id: "{{ groups['elasticsearch-curator'].index(inventory_hostname) }}"
+
+# How frequently Curator runs.
+# For multinode deployments of Curator you should ensure each node has
+# a different schedule so that Curator does not run simultaneously on
+# multiple nodes. Use hostvars or parameterize like in the default
+# below.
+# The default depends on Curator's id as defined above which dictates
+# the daily hour the schedule runs (0, 1, etc.).
+elasticsearch_curator_cron_schedule: "0 {{ elasticsearch_curator_instance_id }} * * *"
 
 # When set to True, Curator will not modify Elasticsearch data, but
 # will print what it *would* do to the Curator log file. This is a


### PR DESCRIPTION
In the spirit of Kolla-Ansible, we generally try to provide
workable defaults.
The default for Elasticsearch curator schedule was fine except for
multinode deploys where it would cause all nodes to run at the
same time producing broken runs (race condition in the get-delete
cycle).
It is easy to improve this situation by embracing poor-man's
reimplementation of keystone's fernet key rotation schedule.
ES Curator does not need all the complexity of the former so it
can be handled very well by shifting by as many hours as the
instance's index dictates. It should rarely if ever need more time
(most likely still in minutes range rather than hours).

Change-Id: I9d6758c8550308d13d936de1a14afbe4124e593b
(cherry picked from commit b82eb1b3936dd305f9826c5d23655273fa10bb0e)