### PR TITLE
Update String type for Monasca ES template

### DIFF
--- a/ansible/roles/monasca/templates/monasca-log-persister/elasticsearch-template.json
+++ b/ansible/roles/monasca/templates/monasca-log-persister/elasticsearch-template.json
@@ -13,9 +13,9 @@
               "fielddata": {
                 "format": "disabled"
               },
-              "index": "analyzed",
+              "index": true,
               "omit_norms": true,
-              "type": "string"
+              "type": "text"
             },
             "match": "message",
             "match_mapping_type": "string"
@@ -24,8 +24,8 @@
         {
           "other_fields": {
             "mapping": {
-              "index": "not_analyzed",
-              "type": "string"
+              "index": true,
+              "type": "keyword"
             },
             "match": "*",
             "match_mapping_type": "string"
@@ -37,8 +37,8 @@
           "type": "date"
         },
         "@version": {
-          "index": "not_analyzed",
-          "type": "string"
+          "index": true,
+          "type": "keyword"
         },
         "creation_time": {
           "type": "date"

--- a/releasenotes/notes/update-monasca-elasticsearch-template-41492c59acaf92b1.yaml
+++ b/releasenotes/notes/update-monasca-elasticsearch-template-41492c59acaf92b1.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes `LP#1892376
+    <https://bugs.launchpad.net/kolla-ansible/+bug/1892376>`__ by updating
+    deprecated syntax in the Monasca Elasticsearch template.


### PR DESCRIPTION
This updates the Elasticsearch template used by Monasca to
persist logs so that is uses the 'new' string types [1]. As
an aside it helps to make the template more clear; full text
search for log messages, and keyword searches for everything
else.

[1] https://www.elastic.co/blog/strings-are-dead-long-live-strings

Closes-Bug: #1892376
Change-Id: I0cd6bf22d4695d88d93241da4364d170d8d8c80e