### PR TITLE
Extend support for custom Grafana dashboards

### DIFF
--- a/ansible/roles/grafana/tasks/config.yml
+++ b/ansible/roles/grafana/tasks/config.yml
@@ -139,26 +139,12 @@
     - inventory_hostname in groups[service.group]
     - service.enabled | bool
 
-- name: Create custom Grafana dashboards folder
-  become: true
-  vars:
-    service: "{{ grafana_services['grafana'] }}"
-  file:
-    dest: "{{ node_config_directory }}/grafana/dashboards/"
-    state: "directory"
-    mode: "0770"
-  when:
-    - grafana_custom_dashboards_folder.stat.exists
-    - grafana_custom_dashboards_folder.stat.isdir
-    - inventory_hostname in groups[service.group]
-    - service.enabled | bool
-
 - name: Copying over custom dashboards
   vars:
     service: "{{ grafana_services['grafana'] }}"
   copy:
-    src: "{{ item }}"
-    dest: "{{ node_config_directory }}/grafana/dashboards/"
+    src: "{{ node_custom_config }}/grafana/dashboards"
+    dest: "{{ node_config_directory }}/grafana/"
     mode: "0660"
   become: true
   when:
@@ -166,7 +152,5 @@
     - grafana_custom_dashboards_folder.stat.isdir
     - inventory_hostname in groups[service.group]
     - service.enabled | bool
-  with_fileglob:
-    - "{{ node_custom_config }}/grafana/dashboards/*.json"
   notify:
     - Restart grafana container

--- a/doc/source/reference/logging-and-monitoring/grafana-guide.rst
+++ b/doc/source/reference/logging-and-monitoring/grafana-guide.rst
@@ -35,9 +35,11 @@ Custom Dashboards Provisioning
 
 Kolla Ansible sets Custom Dashboards Provisioning using `Dashboard provider <https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards>`_.
 
-Dashboard's JSON files should be placed into
-``{{ node_custom_config }}/grafana/dashboards/`` folder.
-Dashboards will be imported to Grafana dashboards General Folder.
+Dashboard JSON files should be placed into the
+``{{ node_custom_config }}/grafana/dashboards/`` folder. The use of
+sub-folders if also supported when using a custom ``provisioning.yaml``
+file. Dashboards will be imported into the Grafana dashboards 'General'
+folder by default.
 
 Grafana provisioner config can be altered by placing ``provisioning.yaml`` to
 ``{{ node_custom_config }}/grafana/`` folder.


### PR DESCRIPTION
The current behaviour is to support supplying a single
folder of Grafana dashboards which can then be populated
into a single folder in Grafana. Some users may wish
to have sub-folders of Dashboards, and load these into
separate dashboard folders in Grafana via a custom
provisioning file. For example, a user may have a
sub-folder of Ceph dashboards that they wish to keep
separate from OpenStack dashboards. This patch supports
sub-folders whilst not affecting the original mechanism.

Trivial-Fix

Change-Id: I9cd289a1ea79f00cee4d2ef30cbb508ac73f9767