### PR TITLE
Victoria: Disable exporting OS cgroups' metrics

### DIFF
--- a/ansible/roles/prometheus/defaults/main.yml
+++ b/ansible/roles/prometheus/defaults/main.yml
@@ -249,3 +249,5 @@ prometheus_openstack_exporter_disabled_dns: "{{ '--disable-service.dns' if not e
 prometheus_openstack_exporter_disabled_object: "{{ '--disable-service.object-store' if not enable_swift | bool else '' }}"
 prometheus_openstack_exporter_disabled_lb: "{{ '--disable-service.load-balancer --disable-metric=neutron-loadbalancers --disable-metric=neutron-loadbalancers_not_active' if not enable_octavia | bool else '' }}"
 prometheus_openstack_exporter_disabled_items: "{{ [prometheus_openstack_exporter_disabled_volume, prometheus_openstack_exporter_disabled_dns, prometheus_openstack_exporter_disabled_object, prometheus_openstack_exporter_disabled_lb|trim]|join(' ')|trim }}"
+
+prometheus_cadvisor_cmdline_extras: "--docker_only --store_container_labels=false"

--- a/ansible/roles/prometheus/templates/prometheus-cadvisor.json.j2
+++ b/ansible/roles/prometheus/templates/prometheus-cadvisor.json.j2
@@ -1,5 +1,5 @@
 {
-    "command": "/opt/cadvisor --port={{ prometheus_cadvisor_port }} --log_dir=/var/log/kolla/prometheus",
+    "command": "/opt/cadvisor {{ prometheus_cadvisor_cmdline_extras }} --port={{ prometheus_cadvisor_port }} --log_dir=/var/log/kolla/prometheus",
     "config_files": [],
     "permissions": [
         {

--- a/etc/kolla/globals.yml
+++ b/etc/kolla/globals.yml
@@ -668,6 +668,10 @@
 # List of extra parameters passed to prometheus. You can add as many to the list.
 #prometheus_cmdline_extras:
 
+# List of extra parameters passed to cAdvisor. By default system cgroups
+# and container labels are not exposed to reduce time series cardinality.
+#prometheus_cadvisor_cmdline_extras: "--docker_only --store_container_labels=false"
+
 # Example of setting endpoints for prometheus ceph mgr exporter.
 # You should add all ceph mgr's in your external ceph deployment.
 #prometheus_ceph_mgr_exporter_endpoints:

--- a/releasenotes/notes/reduce-cadvisor-cardinality-1213854b9fe0c828.yaml
+++ b/releasenotes/notes/reduce-cadvisor-cardinality-1213854b9fe0c828.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Adds support for passing extra runtime options to cAdvisor via
+    ``prometheus_cadvisor_cmdline_extras`` new variable. By default
+    system cgroups' metrics are disabled, plus container labels
+    don't get exposed to Prometheus. This creates savings in resources
+    usage by both cAdvisor and Prometheus.


### PR DESCRIPTION
Backport of the upstream proposed change:

Adds support for passing extra runtime options to cAdvisor.
By default new options disable exporting rarely useful metrics
and labels by cAdvisor. This helps reducing the load on Prometheus
and cAdvisor itself.

Change-Id: Id0144e8fa518e3236cb94ba2e3961fb455d36443