### PR TITLE
Set the correct order of cAdvisor command line flags

### DIFF
--- a/ansible/roles/prometheus/templates/prometheus-cadvisor.json.j2
+++ b/ansible/roles/prometheus/templates/prometheus-cadvisor.json.j2
@@ -1,5 +1,5 @@
 {
-    "command": "/opt/cadvisor {{ prometheus_cadvisor_cmdline_extras }} --port={{ prometheus_cadvisor_port }} --log_dir=/var/log/kolla/prometheus",
+    "command": "/opt/cadvisor --port={{ prometheus_cadvisor_port }} --log_dir=/var/log/kolla/prometheus {{ prometheus_cadvisor_cmdline_extras }}",
     "config_files": [],
     "permissions": [
         {


### PR DESCRIPTION
Apparently, cAdvisor will ignore `--port` flag passed after customised ones and would listen on a default `8080` port. This breaks any existing Prometheus scrape configurations.

Therefore, tag `stackhpc/11.0.0.9` should not be used.