### PR TITLE
Fix broken or conditional

### DIFF
--- a/ansible/roles/baremetal/tasks/post-install.yml
+++ b/ansible/roles/baremetal/tasks/post-install.yml
@@ -164,7 +164,7 @@
     recurse: yes
   when: >
     docker_custom_option | length > 0 or
-    (docker_configure_for_zun | bool and 'zun-compute' in group_names)
+    (docker_configure_for_zun | bool and 'zun-compute' in group_names) or
     docker_http_proxy | length > 0 or
     docker_https_proxy | length > 0 or
     docker_no_proxy | length > 0
@@ -176,7 +176,7 @@
     dest: /etc/systemd/system/docker.service.d/kolla.conf
   when: >
     docker_custom_option | length > 0 or
-    (docker_configure_for_zun | bool and 'zun-compute' in group_names)
+    (docker_configure_for_zun | bool and 'zun-compute' in group_names) or
     docker_http_proxy | length > 0 or
     docker_https_proxy | length > 0 or
     docker_no_proxy | length > 0


### PR DESCRIPTION
```
TASK [baremetal : Ensure docker service directory exists] ************************************************************************************************************************************************************************************

fatal: [seskscposh023]: FAILED! =>

  msg: |-

    The conditional check 'docker_custom_option | length > 0 or (docker_configure_for_zun | bool and 'zun-compute' in group_names) docker_http_proxy | length > 0 or docker_https_proxy | length > 0 or docker_no_proxy | length > 0

    ' failed. The error was: template error while templating string: expected token 'end of statement block', got 'docker_http_proxy'. String: {% if docker_custom_option | length > 0 or (docker_configure_for_zun | bool and 'zun-compute' in group_names) docker_http_proxy | length > 0 or docker_https_proxy | length > 0 or docker_no_proxy | length > 0

     %} True {% else %} False {% endif %}

    The error appears to be in '/var/lib/home/stackhpc/will/kayobe-env/venvs/kolla-ansible/share/kolla-ansible/ansible/roles/baremetal/tasks/post-install.yml': line 159, column 3, but may

    be elsewhere in the file depending on the exact syntax problem.

    The offending line appears to be:

    - name: Ensure docker service directory exists

      ^ here
```