### PR TITLE
Support multiple inventories

### DIFF
--- a/doc/source/user/operating-kolla.rst
+++ b/doc/source/user/operating-kolla.rst
@@ -201,6 +201,12 @@ necessary update containers, without generating configuration.
 ``kolla-ansible -i INVENTORY prune-images`` is used to prune orphaned Docker
 images on hosts.
 
+``kolla-ansible -i INVENTORY1 -i INVENTORY2 ...`` Multiple inventories can be
+specified by passing the ``--inventory`` or ``-i`` command line option multiple
+times. This can be useful to share configuration between multiple environments.
+Any common configuration can be set in ``INVENTORY1`` and ``INVENTORY2`` can be
+used to set environment specific details.
+
 .. note::
 
    In order to do smoke tests, requires ``kolla_enable_sanity_checks=yes``.

--- a/releasenotes/notes/support-multiple-inventories-f0b694fa4e78bb8a.yaml
+++ b/releasenotes/notes/support-multiple-inventories-f0b694fa4e78bb8a.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    It is now possible to pass multiple inventories to ``kolla-ansible``. To do
+    so you should specify ``--inventory`` multiple times.

--- a/tools/kolla-ansible
+++ b/tools/kolla-ansible
@@ -125,7 +125,8 @@ function usage {
 Usage: $0 COMMAND [options]
 
 Options:
-    --inventory, -i <inventory_path>   Specify path to ansible inventory file
+    --inventory, -i <inventory_path>   Specify path to ansible inventory file. \
+Can be specified multiple times to pass multiple inventories.
     --playbook, -p <playbook_path>     Specify path to ansible playbook file
     --configdir <config_path>          Specify path to directory with globals.yml
     --key -k <key_path>                Specify path to ansible vault keyfile
@@ -243,12 +244,13 @@ BACKUP_TYPE="full"
 # Serial is not recommended and disabled by default. Users can enable it by
 # configuring ANSIBLE_SERIAL variable.
 ANSIBLE_SERIAL=${ANSIBLE_SERIAL:-0}
+INVENTORIES=()
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
 
     (--inventory|-i)
-            INVENTORY="$2"
+            INVENTORIES+=("$2")
             shift 2
             ;;
 
@@ -516,5 +518,8 @@ GLOBALS_DIR="${CONFIG_DIR}/globals.d"
 EXTRA_GLOBALS=$(find ${GLOBALS_DIR} -maxdepth 1 -type f -name '*.yml' -printf ' -e @%p' 2>/dev/null)
 PASSWORDS_FILE="${PASSWORDS_FILE:-${CONFIG_DIR}/passwords.yml}"
 CONFIG_OPTS="-e @${CONFIG_DIR}/globals.yml ${EXTRA_GLOBALS} -e @${PASSWORDS_FILE} -e CONFIG_DIR=${CONFIG_DIR}"
-CMD="ansible-playbook -i $INVENTORY $CONFIG_OPTS $EXTRA_OPTS $PLAYBOOK $VERBOSITY"
+CMD="ansible-playbook $CONFIG_OPTS $EXTRA_OPTS $PLAYBOOK $VERBOSITY"
+for INVENTORY in ${INVENTORIES[@]}; do
+    CMD="${CMD} --inventory $INVENTORY"
+done
 process_cmd


### PR DESCRIPTION
Multiple inventories can now be passed to `kolla-ansible`.  This can be
useful to construct a common inventory that is shared between multiple
environments.

Change-Id: I2ac5d7851b310bea2ba362b353f18c592a0a6a2e
(cherry picked from commit 6c72fa811739573c502240d9ee93bf1823d20447)