### PR TITLE
Add suppress_type_name to stop warnings with ES7

### DIFF
--- a/ansible/roles/common/templates/conf/output/00-local.conf.j2
+++ b/ansible/roles/common/templates/conf/output/00-local.conf.j2
@@ -35,6 +35,7 @@
        reconnect_on_error true
        buffer_type file
        buffer_path /var/lib/fluentd/data/elasticsearch.buffer/{{ syslog_swift_facility }}.*
+       suppress_type_name true
   </store>
 {% elif enable_monasca | bool and monasca_ingest_control_plane_logs | bool %}
   <store>
@@ -97,6 +98,7 @@
        reconnect_on_error true
        buffer_type file
        buffer_path /var/lib/fluentd/data/elasticsearch.buffer/{{ syslog_haproxy_facility }}.*
+       suppress_type_name true
   </store>
 {% elif enable_monasca | bool and monasca_ingest_control_plane_logs | bool %}
   <store>
@@ -157,6 +159,7 @@
        reconnect_on_error true
        buffer_type file
        buffer_path /var/lib/fluentd/data/elasticsearch.buffer/{{ syslog_glance_tls_proxy_facility }}.*
+       suppress_type_name true
   </store>
 {% elif enable_monasca | bool and monasca_ingest_control_plane_logs | bool %}
   <store>
@@ -218,6 +221,7 @@
        reconnect_on_error true
        buffer_type file
        buffer_path /var/lib/fluentd/data/elasticsearch.buffer/{{ syslog_neutron_tls_proxy_facility }}.*
+       suppress_type_name true
   </store>
 {% elif enable_monasca | bool and monasca_ingest_control_plane_logs | bool %}
   <store>

--- a/ansible/roles/common/templates/conf/output/01-es.conf.j2
+++ b/ansible/roles/common/templates/conf/output/01-es.conf.j2
@@ -25,5 +25,6 @@
        reconnect_on_error true
        buffer_type file
        buffer_path /var/lib/fluentd/data/elasticsearch.buffer/openstack.*
+       suppress_type_name true
     </store>
 </match>

--- a/releasenotes/notes/fix_supress_type_warning-59f87fe62f83bd12.yaml
+++ b/releasenotes/notes/fix_supress_type_warning-59f87fe62f83bd12.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Stops Fluentd warning message when posting to Elasticsearch 7 bulk
+    API.


### PR DESCRIPTION
When using elasticsearch 7 with fluentd, you seem to get a lot
of warnings in the docker logs output that look like:

    [types removal] Specifying types in bulk requests is deprecated.

The docs suggest adding suppress_type_name to stop these warnings,
and that seems to work without affecting any functionality.

Further info here:
https://github.com/uken/fluent-plugin-elasticsearch/issues/785

Closes-Bug: #1930856
Change-Id: I45be67df3717f78d78bcdc7df69600ab8681922f
(cherry picked from commit dee9d22dcf4910f8b94612872846df695d268165)