### PR TITLE
Support copying static Vendordata file into Nova API container

### DIFF
--- a/ansible/roles/nova/tasks/config.yml
+++ b/ansible/roles/nova/tasks/config.yml
@@ -31,6 +31,13 @@
   when:
     - nova_policy.results
 
+- name: Check for vendordata file
+  stat:
+    path: "{{ node_custom_config }}/nova/vendordata.json"
+  delegate_to: localhost
+  run_once: True
+  register: vendordata_file
+
 - include_tasks: copy-certs.yml
   when:
     - kolla_copy_ca_into_containers | bool or nova_enable_tls_backend | bool
@@ -92,5 +99,20 @@
   when:
     - inventory_hostname in groups["nova-api"]
     - nova_services["nova-api"].enabled | bool
+  notify:
+    - "Restart nova-api container"
+
+- name: Copying over vendordata file
+  vars:
+    service: "{{ nova_services['nova-api'] }}"
+  copy:
+    src: "{{ vendordata_file.stat.path }}"
+    dest: "{{ node_config_directory }}/nova-api/vendordata.json"
+    mode: "0660"
+  become: True
+  when:
+    - vendordata_file.stat.path is defined
+    - inventory_hostname in groups[service['group']]
+    - service.enabled | bool
   notify:
     - "Restart nova-api container"

--- a/ansible/roles/nova/templates/nova-api.json.j2
+++ b/ansible/roles/nova/templates/nova-api.json.j2
@@ -32,6 +32,12 @@
             "dest": "/etc/nova/certs/nova-key.pem",
             "owner": "nova",
             "perm": "0600"
+        }{% endif %}{% if vendordata_file.stat.path is defined %},
+        {
+            "source": "{{ container_config_directory }}/vendordata.json",
+            "dest": "/etc/nova/vendordata.json",
+            "owner": "nova",
+            "perm": "0600"
         }{% endif %}
     ],
     "permissions": [

--- a/ansible/roles/nova/templates/nova.conf.j2
+++ b/ansible/roles/nova/templates/nova.conf.j2
@@ -38,6 +38,10 @@ track_instance_changes = False
 [api]
 use_forwarded_for = true
 
+{% if vendordata_file.stat.path is defined %}
+vendordata_jsonfile_path = /etc/nova/vendordata.json
+{% endif %}
+
 # Super conductor
 [conductor]
 workers = {{ openstack_service_workers }}

--- a/doc/source/reference/compute/nova-guide.rst
+++ b/doc/source/reference/compute/nova-guide.rst
@@ -56,3 +56,12 @@ Cells
 
 Information on using Nova Cells V2 to scale out can be found in
 :doc:`nova-cells-guide`.
+
+Vendordata
+==========
+
+Nova supports passing deployer provided data to instances using a
+concept known as Vendordata. If a Vendordata file is located in the
+following path within the Kolla configuration, Kolla will
+automatically use it when the Nova service is deployed or
+reconfigured: ``/etc/kolla/config/nova/vendordata.json``.

--- a/releasenotes/notes/support-setting-vendordata-34f78d9004fa369a.yaml
+++ b/releasenotes/notes/support-setting-vendordata-34f78d9004fa369a.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Support for configuring a Vendordata file for Nova has been
+    added. This allows users to pass through arbitrary data to
+    instances.


### PR DESCRIPTION
Nova provides a mechanism to set static vendordata via a file [1].
This patch provides support in Kolla Ansible for using this
feature.

Arguably this could be part of a generic mechansim for copying
arbitrary config, but:

- It's not clear if there is anything else that would take
  advantage of this
- One size might not fit all

[1] https://docs.openstack.org/nova/latest/configuration/config.html#api.vendordata_jsonfile_path

Change-Id: Id420376d96d0c40415c369ae8dd36e845a781820