### PR TITLE
Add support for deploying prometheus-msteams

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -463,6 +463,9 @@ prometheus_fluentd_integration_port: "24231"
 prometheus_alertmanager_port: "9093"
 prometheus_alertmanager_cluster_port: "9094"
 
+# Prometheus MSTeams port
+prometheus_msteams_port: "9095"
+
 # Prometheus openstack-exporter ports
 prometheus_openstack_exporter_port: "9198"
 prometheus_elasticsearch_exporter_port: "9108"
@@ -1114,8 +1117,11 @@ enable_prometheus_openstack_exporter: "{{ enable_prometheus | bool }}"
 enable_prometheus_elasticsearch_exporter: "{{ enable_prometheus | bool and enable_elasticsearch | bool }}"
 enable_prometheus_blackbox_exporter: "{{ enable_prometheus | bool }}"
 enable_prometheus_rabbitmq_exporter: "{{ enable_prometheus | bool and enable_rabbitmq | bool }}"
+enable_prometheus_msteams: "no"
 
 prometheus_alertmanager_user: "admin"
+# Webhook URL used to post alerts to Microsoft Teams
+prometheus_msteams_webhook_url:
 prometheus_openstack_exporter_interval: "60s"
 prometheus_openstack_exporter_timeout: "10s"
 prometheus_elasticsearch_exporter_interval: "60s"

--- a/ansible/inventory/all-in-one
+++ b/ansible/inventory/all-in-one
@@ -729,6 +729,9 @@ elasticsearch
 [prometheus-blackbox-exporter:children]
 monitoring
 
+[prometheus-msteams:children]
+prometheus-alertmanager
+
 [masakari-api:children]
 control
 

--- a/ansible/inventory/multinode
+++ b/ansible/inventory/multinode
@@ -747,6 +747,9 @@ elasticsearch
 [prometheus-blackbox-exporter:children]
 monitoring
 
+[prometheus-msteams:children]
+prometheus-alertmanager
+
 [masakari-api:children]
 control
 

--- a/ansible/roles/prometheus/defaults/main.yml
+++ b/ansible/roles/prometheus/defaults/main.yml
@@ -94,6 +94,13 @@ prometheus_services:
     image: "{{ prometheus_blackbox_exporter_image_full }}"
     volumes: "{{ prometheus_blackbox_exporter_default_volumes + prometheus_blackbox_exporter_extra_volumes }}"
     dimensions: "{{ prometheus_blackbox_exporter_dimensions }}"
+  prometheus-msteams:
+    container_name: "prometheus_msteams"
+    group: "prometheus-msteams"
+    enabled: "{{ enable_prometheus_msteams | bool }}"
+    image: "{{ prometheus_msteams_image_full }}"
+    volumes: "{{ prometheus_msteams_default_volumes + prometheus_msteams_extra_volumes }}"
+    dimensions: "{{ prometheus_msteams_dimensions }}"
 
 ####################
 # Database
@@ -168,6 +175,10 @@ prometheus_blackbox_exporter_image: "{{ docker_registry ~ '/' if docker_registry
 prometheus_blackbox_exporter_tag: "{{ prometheus_tag }}"
 prometheus_blackbox_exporter_image_full: "{{ prometheus_blackbox_exporter_image }}:{{ prometheus_blackbox_exporter_tag }}"
 
+prometheus_msteams_image: "{{ docker_registry ~ '/' if docker_registry else '' }}{{ docker_namespace }}/{{ kolla_base_distro }}-{{ prometheus_install_type }}-prometheus-msteams"
+prometheus_msteams_tag: "{{ prometheus_tag }}"
+prometheus_msteams_image_full: "{{ prometheus_msteams_image }}:{{ prometheus_msteams_tag }}"
+
 prometheus_server_dimensions: "{{ default_container_dimensions }}"
 prometheus_haproxy_exporter_dimensions: "{{ default_container_dimensions }}"
 prometheus_mysqld_exporter_dimensions: "{{ default_container_dimensions }}"
@@ -178,6 +189,7 @@ prometheus_alertmanager_dimensions: "{{ default_container_dimensions }}"
 prometheus_openstack_exporter_dimensions: "{{ default_container_dimensions }}"
 prometheus_elasticsearch_exporter_dimensions: "{{ default_container_dimensions }}"
 prometheus_blackbox_exporter_dimensions: "{{ default_container_dimensions }}"
+prometheus_msteams_dimensions: "{{ default_container_dimensions }}"
 
 prometheus_server_default_volumes:
   - "{{ node_config_directory }}/prometheus-server/:{{ container_config_directory }}/:ro"
@@ -239,6 +251,11 @@ prometheus_blackbox_exporter_default_volumes:
   - "/etc/localtime:/etc/localtime:ro"
   - "{{ '/etc/timezone:/etc/timezone:ro' if ansible_facts.os_family == 'Debian' else '' }}"
   - "kolla_logs:/var/log/kolla/"
+prometheus_msteams_default_volumes:
+  - "{{ node_config_directory }}/prometheus-msteams/:{{ container_config_directory }}/:ro"
+  - "/etc/localtime:/etc/localtime:ro"
+  - "{{ '/etc/timezone:/etc/timezone:ro' if ansible_facts.os_family == 'Debian' else '' }}"
+  - "kolla_logs:/var/log/kolla/"
 
 prometheus_extra_volumes: "{{ default_extra_volumes }}"
 prometheus_server_extra_volumes: "{{ prometheus_extra_volumes }}"
@@ -251,6 +268,7 @@ prometheus_alertmanager_extra_volumes: "{{ prometheus_extra_volumes }}"
 prometheus_openstack_exporter_extra_volumes: "{{ prometheus_extra_volumes }}"
 prometheus_elasticsearch_exporter_extra_volumes: "{{ prometheus_extra_volumes }}"
 prometheus_blackbox_exporter_extra_volumes: "{{ prometheus_extra_volumes }}"
+prometheus_msteams_extra_volumes: "{{ prometheus_extra_volumes }}"
 
 prometheus_openstack_exporter_disabled_volume: "{{ '--disable-service.volume' if not enable_cinder | bool else '' }}"
 prometheus_openstack_exporter_disabled_dns: "{{ '--disable-service.dns' if not enable_designate | bool else '' }}"

--- a/ansible/roles/prometheus/handlers/main.yml
+++ b/ansible/roles/prometheus/handlers/main.yml
@@ -149,3 +149,18 @@
     dimensions: "{{ service.dimensions }}"
   when:
     - kolla_action != "config"
+
+- name: Restart prometheus-msteams container
+  vars:
+    service_name: "prometheus-msteams"
+    service: "{{ prometheus_services[service_name] }}"
+  become: true
+  kolla_docker:
+    action: "recreate_or_restart_container"
+    common_options: "{{ docker_common_options }}"
+    name: "{{ service.container_name }}"
+    image: "{{ service.image }}"
+    volumes: "{{ service.volumes }}"
+    dimensions: "{{ service.dimensions }}"
+  when:
+    - kolla_action != "config"

--- a/ansible/roles/prometheus/tasks/config.yml
+++ b/ansible/roles/prometheus/tasks/config.yml
@@ -211,3 +211,37 @@
   when:
     - inventory_hostname in groups[service.group]
     - service.enabled | bool
+
+- name: Copying over prometheus msteams config file
+  vars:
+    service: "{{ prometheus_services['prometheus-msteams'] }}"
+  template:
+    src: "{{ item }}"
+    dest: "{{ node_config_directory }}/prometheus-msteams/msteams.yml"
+  become: true
+  when:
+    - inventory_hostname in groups[service.group]
+    - service.enabled | bool
+  with_first_found:
+    - "{{ node_custom_config }}/prometheus/{{ inventory_hostname }}/prometheus-msteams.yml"
+    - "{{ node_custom_config }}/prometheus/prometheus-msteams.yml"
+    - "{{ role_path }}/templates/prometheus-msteams.yml.j2"
+  notify:
+    - Restart prometheus-msteams container
+
+- name: Copying over prometheus msteams template file
+  vars:
+    service: "{{ prometheus_services['prometheus-msteams'] }}"
+  copy:
+    src: "{{ item }}"
+    dest: "{{ node_config_directory }}/prometheus-msteams/msteams.tmpl"
+  become: true
+  when:
+    - inventory_hostname in groups[service.group]
+    - service.enabled | bool
+  with_first_found:
+    - "{{ node_custom_config }}/prometheus/{{ inventory_hostname }}/prometheus-msteams.tmpl"
+    - "{{ node_custom_config }}/prometheus/prometheus-msteams.tmpl"
+    - "{{ role_path }}/templates/prometheus-msteams.tmpl"
+  notify:
+    - Restart prometheus-msteams container

--- a/ansible/roles/prometheus/templates/prometheus-alertmanager.yml.j2
+++ b/ansible/roles/prometheus/templates/prometheus-alertmanager.yml.j2
@@ -6,6 +6,10 @@ route:
   group_wait: 10s
   group_interval: 5m
   repeat_interval: 3h
+{% if enable_prometheus_msteams | bool %}
+  routes:
+    - receiver: 'prometheus-msteams'
+{% endif %}
 receivers:
   - name: default-receiver
 {% if enable_vitrage | bool and enable_vitrage_prometheus_datasource | bool %}
@@ -16,5 +20,11 @@ receivers:
           basic_auth:
             username: '{{ keystone_admin_user }}'
             password: '{{ keystone_admin_password }}'
+{% endif %}
+{% if enable_prometheus_msteams | bool %}
+  - name: 'prometheus-msteams'
+    webhook_configs:
+    - send_resolved: true
+      url: 'http://localhost:{{ prometheus_msteams_port }}/alertmanager'
 {% endif %}
 templates: []

--- a/ansible/roles/prometheus/templates/prometheus-msteams.json.j2
+++ b/ansible/roles/prometheus/templates/prometheus-msteams.json.j2
@@ -1,0 +1,24 @@
+{
+    "command": "/opt/prometheus-msteams -http-addr localhost:{{ prometheus_msteams_port }} -config-file /etc/msteams/msteams.yml -template-file /etc/msteams/msteams.tmpl",
+    "config_files": [
+        {
+            "source": "{{ container_config_directory }}/msteams.yml",
+            "dest": "/etc/msteams/msteams.yml",
+            "owner": "prometheus",
+            "perm": "0600"
+        },
+        {
+            "source": "{{ container_config_directory }}/msteams.tmpl",
+            "dest": "/etc/msteams/msteams.tmpl",
+            "owner": "prometheus",
+            "perm": "0600"
+        }
+    ],
+    "permissions": [
+        {
+            "path": "/var/log/kolla/prometheus",
+            "owner": "prometheus:kolla",
+            "recurse": true
+        }
+    ]
+}

--- a/ansible/roles/prometheus/templates/prometheus-msteams.tmpl
+++ b/ansible/roles/prometheus/templates/prometheus-msteams.tmpl
@@ -1,0 +1,50 @@
+{{ define "teams.card" }}
+{
+  "@type": "MessageCard",
+  "@context": "http://schema.org/extensions",
+  "themeColor": "{{- if eq .Status "resolved" -}}2DC72D
+                 {{- else if eq .Status "firing" -}}
+                    {{- if eq .CommonLabels.severity "critical" -}}8C1A1A
+                    {{- else if eq .CommonLabels.severity "warning" -}}FFA500
+                    {{- else -}}808080{{- end -}}
+                 {{- else -}}808080{{- end -}}",
+  "summary": "{{- if eq .CommonAnnotations.summary "" -}}
+                  {{- if eq .CommonAnnotations.message "" -}}
+                    {{- if eq .CommonLabels.alertname "" -}}
+                      Prometheus Alert
+                    {{- else -}}
+                      {{- .CommonLabels.alertname -}}
+                    {{- end -}}
+                  {{- else -}}
+                    {{- .CommonAnnotations.message -}}
+                  {{- end -}}
+              {{- else -}}
+                  {{- .CommonAnnotations.summary -}}
+              {{- end -}}",
+  "title": "Prometheus Alert ({{ .Status | title }})",
+  "sections": [ {{$externalUrl := .ExternalURL}}
+  {{- range $index, $alert := .Alerts }}{{- if $index }},{{- end }}
+    {
+      "activityTitle": "[{{ $alert.Annotations.description }}]({{ $externalUrl }})",
+      "facts": [
+        {{- range $key, $value := $alert.Annotations }}
+        {
+          {{- if ne $key "description" -}}
+            "name": "{{ $key }}",
+            "value": "{{ $value }}"
+          {{- end -}}
+        },
+        {{- end -}}
+        {{$c := counter}}{{ range $key, $value := $alert.Labels }}{{if call $c}},{{ end }}
+        {
+          "name": "{{ $key }}",
+          "value": "{{ $value }}"
+        }
+        {{- end }}
+      ],
+      "markdown": true
+    }
+    {{- end }}
+  ]
+}
+{{ end }}

--- a/ansible/roles/prometheus/templates/prometheus-msteams.yml.j2
+++ b/ansible/roles/prometheus/templates/prometheus-msteams.yml.j2
@@ -1,0 +1,2 @@
+connectors:
+  - alertmanager: "{{ prometheus_msteams_webhook_url }}"

--- a/etc/kolla/globals.yml
+++ b/etc/kolla/globals.yml
@@ -718,6 +718,7 @@
 #enable_prometheus_openstack_exporter: "{{ enable_prometheus | bool }}"
 #enable_prometheus_elasticsearch_exporter: "{{ enable_prometheus | bool and enable_elasticsearch | bool }}"
 #enable_prometheus_blackbox_exporter: "{{ enable_prometheus | bool }}"
+#enable_prometheus_msteams: "no"
 
 # List of extra parameters passed to prometheus. You can add as many to the list.
 #prometheus_cmdline_extras:

--- a/releasenotes/notes/prometheus-msteams-361a2b76300e7921.yaml
+++ b/releasenotes/notes/prometheus-msteams-361a2b76300e7921.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds support for deploying ``prometheus-msteams``, which can be used to
+    forward Prometheus Alertmanager notifications to Microsoft Teams.


### PR DESCRIPTION
This can be used to forward Prometheus Alertmanager notifications to
Microsoft Teams.

Change-Id: I563f2438b3cb0895606b029b5269ce2e50c413e3
Depends-On: https://review.opendev.org/c/openstack/kolla/+/812678
(cherry picked from commit aad231a32a7f7a81db9c10e30c91fba534a49be6)