### PR TITLE
Use the 8-series Docker repo for Train-CentOS8

### DIFF
--- a/ansible/roles/baremetal/defaults/main.yml
+++ b/ansible/roles/baremetal/defaults/main.yml
@@ -11,9 +11,7 @@ docker_apt_package: "docker-ce"
 
 # Docker Yum repository configuration.
 docker_yum_url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}"
-# FIXME(mgoddard): Use {{ ansible_distribution_major_version | lower }} rather
-# than 7.
-docker_yum_baseurl: "{{ docker_yum_url }}/7/$basearch/stable"
+docker_yum_baseurl: "{{ docker_yum_url }}/$releasever/$basearch/stable"
 docker_yum_gpgkey: "{{ docker_yum_url }}/gpg"
 docker_yum_gpgcheck: true
 docker_yum_package: "docker-ce"


### PR DESCRIPTION
I'm assuming it's too late for stable/train upstream but we should carry this minor patch: When using Train CentOS 8, we should update the Docker repo URL accordingly.