### PR TITLE
Wallaby: Remove classic queue mirroring for internal RabbitMQ

### DIFF
--- a/ansible/roles/rabbitmq/tasks/upgrade.yml
+++ b/ansible/roles/rabbitmq/tasks/upgrade.yml
@@ -16,6 +16,28 @@
   when: inventory_hostname in groups[role_rabbitmq_groups]
   register: rabbitmq_differs
 
+- name: List RabbitMQ policies
+  vars:
+    service_name: "rabbitmq"
+    service: "{{ rabbitmq_services[service_name] }}"
+  become: true
+  command: "docker exec {{ service.container_name }} rabbitmqctl list_policies --silent"
+  when: inventory_hostname in groups[role_rabbitmq_groups]
+  run_once: true
+  register: rabbitmq_policies
+  changed_when: false
+
+# NOTE(dszumski): This can be removed in the Zed cycle
+- name: Remove ha-all policy from RabbitMQ
+  vars:
+    service_name: "rabbitmq"
+    service: "{{ rabbitmq_services[service_name] }}"
+  become: true
+  command: "docker exec {{ service.container_name }} rabbitmqctl clear_policy ha-all"
+  when:
+    - inventory_hostname in groups[role_rabbitmq_groups] and 'ha-all' in rabbitmq_policies.stdout
+  run_once: true
+
 - import_tasks: config.yml
 
 - import_tasks: check-containers.yml

--- a/ansible/roles/rabbitmq/templates/definitions.json.j2
+++ b/ansible/roles/rabbitmq/templates/definitions.json.j2
@@ -16,9 +16,5 @@
     {"user": "{{ murano_agent_rabbitmq_user }}", "vhost": "{{ murano_agent_rabbitmq_vhost }}", "configure": ".*", "write": ".*", "read": ".*"}
     {% endif %}
   ],
-  "policies":[
-    {"vhost": "/", "name": "ha-all", "pattern": ".*", "apply-to": "all", "definition": {"ha-mode":"all"}, "priority":0}{% if project_name == 'outward_rabbitmq' %},
-    {"vhost": "{{ murano_agent_rabbitmq_vhost }}", "name": "ha-all", "pattern": ".*", "apply-to": "all", "definition": {"ha-mode":"all"}, "priority":0}
-    {% endif %}
-  ]
+  "policies":[]
 }

--- a/releasenotes/notes/remove-queue-mirroring-for-rabbitmq-d54b9e7e25e57a88.yaml
+++ b/releasenotes/notes/remove-queue-mirroring-for-rabbitmq-d54b9e7e25e57a88.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    Fixes an issue where RabbitMQ was configured to mirror classic transient
+    queues for all services. According to the RabbitMQ documentation this is
+    not a supported configuration, and contributed to numerous bug reports.
+    `LP#1954925 <https://launchpad.net/bugs/1954925>`__
+upgrade:
+  - |
+    The policy for classic transient mirrored queues in RabbitMQ has been
+    removed from the RabbitMQ configuration. The policy will be removed
+    automatically during upgrade of the RabbitMQ service.


### PR DESCRIPTION
Backporting https://review.opendev.org/c/openstack/kolla-ansible/+/824994