### PR TITLE
Fix prometheus without prometheus-libvirt-exporter group

### DIFF
--- a/ansible/roles/prometheus/templates/prometheus.yml.j2
+++ b/ansible/roles/prometheus/templates/prometheus.yml.j2
@@ -151,7 +151,7 @@ scrape_configs:
     honor_labels: true
     static_configs:
       - targets:
-{% for host in groups["prometheus-libvirt-exporter"] %}
+{% for host in groups.get("prometheus-libvirt-exporter", []) %}
         - '{{ 'api' | kolla_address(host) | put_address_in_context('url') }}:{{ hostvars[host]['prometheus_libvirt_exporter_port'] }}'
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
If the prometheus-libvirt-exporter group is not in the inventory, the
task "Copying over prometheus config file" fails with:

    "msg": "'dict object' has no attribute 'prometheus-libvirt-exporter'"

Changes [1] and [2] fixed similar issues but missed the use of this
group during templating.

[1] https://review.opendev.org/c/openstack/kolla-ansible/+/833167
[2] https://review.opendev.org/c/openstack/kolla-ansible/+/834620

Change-Id: I86dd8337bf002d7f5ff803c85c5944970e1ab016
(cherry picked from commit fbb2de815f73a44c5d6cfc6e634ff48da8e55eb9)