### PR TITLE
Support specifying Nova compute provider config

### DIFF
--- a/ansible/roles/nova-cell/tasks/config.yml
+++ b/ansible/roles/nova-cell/tasks/config.yml
@@ -74,6 +74,21 @@
   notify:
     - "Restart {{ item.key }} container"
 
+- name: Copying over Nova compute provider config
+  become: true
+  vars:
+    service: "{{ nova_cell_services['nova-compute'] }}"
+  copy:
+    content: "{{ nova_cell_compute_provider_config | to_nice_yaml(indent=2) }}"
+    dest: "{{ node_config_directory }}/nova-compute/provider_config.yaml"
+    mode: "0660"
+  when:
+    - inventory_hostname in groups[service.group]
+    - nova_cell_compute_provider_config is defined
+    - service.enabled | bool
+  notify:
+    - Restart nova-compute container
+
 - name: Copying over libvirt configuration
   become: true
   vars:

--- a/ansible/roles/nova-cell/templates/nova-compute.json.j2
+++ b/ansible/roles/nova-cell/templates/nova-compute.json.j2
@@ -61,7 +61,14 @@
             "dest": "/var/lib/nova/.config/libvirt/auth.conf",
             "owner": "nova",
             "perm": "0600"
-        }{% endif %}
+        }{% endif %},
+        {
+            "source": "{{ container_config_directory }}/provider_config.yaml",
+            "dest": "/etc/nova/provider_config/provider_config.yaml",
+            "owner": "nova",
+            "perm": "0600",
+            "optional": true
+        }
     ],
     "permissions": [
         {

--- a/doc/source/reference/compute/nova-guide.rst
+++ b/doc/source/reference/compute/nova-guide.rst
@@ -65,3 +65,49 @@ concept known as Vendordata. If a Vendordata file is located in the
 following path within the Kolla configuration, Kolla will
 automatically use it when the Nova service is deployed or
 reconfigured: ``/etc/kolla/config/nova/vendordata.json``.
+
+Managing resource providers via config files
+============================================
+
+In the Victoria cycle Nova merged support for managing resource providers
+via `configuration files
+<https://docs.openstack.org/nova/latest/admin/managing-resource-providers.html>`__.
+
+Kolla Ansible limits the use of this feature to a single config file per
+Nova Compute service, which is defined via Ansible inventory group/host vars.
+The reason for doing this is to encourage users to configure each compute
+service individually, so that when further resources are added, existing
+compute services do not need to be restarted.
+
+For example, a user wanting to configure a compute resource with GPUs for
+a specific host may add the following file to host_vars:
+
+.. code-block:: console
+
+    [host_vars]$ cat gpu_compute_0001
+    nova_cell_compute_provider_config:
+      meta:
+        schema_version: '1.0'
+      providers:
+        - identification:
+            name: $COMPUTE_NODE
+          inventories:
+            additional:
+              - CUSTOM_GPU:
+                  total: 8
+                  reserved: 0
+                  min_unit: 1
+                  max_unit: 1
+                  step_size: 1
+                  allocation_ratio: 1.0
+
+A similar approach can be used with group vars to cover more than one machine.
+
+Since a badly formatted file will prevent the Nova Compute service from
+starting, it should first be validated as described in the `documentation
+<https://docs.openstack.org/nova/latest/admin/managing-resource-providers.html>`__.
+The Nova Compute service can then be reconfigured to apply the change.
+
+To remove the resource provider configuration, it is simplest to leave the
+group/host vars in place without specifying any inventory or traits. This will
+effectively remove the configuration when the Nova Compute service is restarted.

--- a/releasenotes/notes/feature-compute-provider-config-9a17105e5c5b048e.yaml
+++ b/releasenotes/notes/feature-compute-provider-config-9a17105e5c5b048e.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds support for managing resource providers via `config files
+    <https://docs.openstack.org/nova/latest/admin/managing-resource-providers.html>`__.


### PR DESCRIPTION
NOTE: This hasn't merged upstream yet, but it's been reviewed and comments addressed so shouldn't change much. I can backport the upstream patch to newer releases when it lands.

In the Victoria cycle, Nova merged improved support for
managing resource providers:
https://review.opendev.org/q/topic:bp%252Fprovider-config-file

See the blueprint for more details:
https://docs.openstack.org/nova/latest/admin/managing-resource-providers.html

This change allows us to copy the necessary configuration.

Change-Id: I0a3caaad73bc6fe27380e7f6bf6b792aca51c84c