### PR TITLE
Allow to define extra parameters for Prometheus exporters

### DIFF
--- a/ansible/roles/prometheus/defaults/main.yml
+++ b/ansible/roles/prometheus/defaults/main.yml
@@ -279,4 +279,11 @@ prometheus_openstack_exporter_disabled_object: "{{ '--disable-service.object-sto
 prometheus_openstack_exporter_disabled_lb: "{{ '--disable-service.load-balancer --disable-metric=neutron-loadbalancers --disable-metric=neutron-loadbalancers_not_active' if not enable_octavia | bool else '' }}"
 prometheus_openstack_exporter_disabled_items: "{{ [prometheus_openstack_exporter_disabled_volume, prometheus_openstack_exporter_disabled_dns, prometheus_openstack_exporter_disabled_object, prometheus_openstack_exporter_disabled_lb|trim]|join(' ')|trim }}"
 
+prometheus_blackbox_exporter_cmdline_extras: ""
 prometheus_cadvisor_cmdline_extras: "--docker_only --store_container_labels=false --disable_metrics=percpu,referenced_memory,cpu_topology,resctrl,udp,advtcp,sched,hugetlb,memory_numa,tcp,process"
+prometheus_elasticsearch_exporter_cmdline_extras: ""
+prometheus_haproxy_exporter_cmdline_extras: ""
+prometheus_memcached_exporter_cmdline_extras: ""
+prometheus_mysqld_exporter_cmdline_extras: ""
+prometheus_node_exporter_cmdline_extras: ""
+prometheus_openstack_exporter_cmdline_extras: ""

--- a/ansible/roles/prometheus/templates/prometheus-blackbox-exporter.json.j2
+++ b/ansible/roles/prometheus/templates/prometheus-blackbox-exporter.json.j2
@@ -1,5 +1,5 @@
 {
-    "command": "/opt/blackbox_exporter/blackbox_exporter --config.file=/etc/prometheus/blackbox.yml --web.listen-address={{ api_interface_address | put_address_in_context('url') }}:{{ prometheus_blackbox_exporter_port }} --log.level=info",
+    "command": "/opt/blackbox_exporter/blackbox_exporter --config.file=/etc/prometheus/blackbox.yml --web.listen-address={{ api_interface_address | put_address_in_context('url') }}:{{ prometheus_blackbox_exporter_port }} --log.level=info{% if prometheus_blackbox_exporter_cmdline_extras %} {{ prometheus_blackbox_exporter_cmdline_extras }}{% endif %}",
     "config_files": [
         {
             "source": "{{ container_config_directory }}/prometheus-blackbox-exporter.yml",

--- a/ansible/roles/prometheus/templates/prometheus-cadvisor.json.j2
+++ b/ansible/roles/prometheus/templates/prometheus-cadvisor.json.j2
@@ -1,5 +1,5 @@
 {
-    "command": "/opt/cadvisor --port={{ prometheus_cadvisor_port }} --log_dir=/var/log/kolla/prometheus {{ prometheus_cadvisor_cmdline_extras }}",
+    "command": "/opt/cadvisor --port={{ prometheus_cadvisor_port }} --log_dir=/var/log/kolla/prometheus{% if prometheus_cadvisor_cmdline_extras %} {{ prometheus_cadvisor_cmdline_extras }}{% endif %}",
     "config_files": [],
     "permissions": [
         {

--- a/ansible/roles/prometheus/templates/prometheus-elasticsearch-exporter.json.j2
+++ b/ansible/roles/prometheus/templates/prometheus-elasticsearch-exporter.json.j2
@@ -1,5 +1,5 @@
 {
-    "command": "/opt/elasticsearch_exporter/elasticsearch_exporter --es.uri http://{{ api_interface_address | put_address_in_context('url') }}:{{ elasticsearch_port }} --web.listen-address {{ api_interface_address | put_address_in_context('url') }}:{{ prometheus_elasticsearch_exporter_port }}",
+    "command": "/opt/elasticsearch_exporter/elasticsearch_exporter --es.uri http://{{ api_interface_address | put_address_in_context('url') }}:{{ elasticsearch_port }} --web.listen-address {{ api_interface_address | put_address_in_context('url') }}:{{ prometheus_elasticsearch_exporter_port }}{% if prometheus_elasticsearch_exporter_cmdline_extras %} {{ prometheus_elasticsearch_exporter_cmdline_extras }}{% endif %}",
     "config_files": [],
     "permissions": [
         {

--- a/ansible/roles/prometheus/templates/prometheus-haproxy-exporter.json.j2
+++ b/ansible/roles/prometheus/templates/prometheus-haproxy-exporter.json.j2
@@ -1,5 +1,5 @@
 {
-    "command": "/opt/haproxy_exporter/haproxy_exporter --haproxy.scrape-uri unix:/var/lib/kolla/haproxy/haproxy.sock --web.listen-address {{ api_interface_address | put_address_in_context('url') }}:{{ prometheus_haproxy_exporter_port }}",
+    "command": "/opt/haproxy_exporter/haproxy_exporter --haproxy.scrape-uri unix:/var/lib/kolla/haproxy/haproxy.sock --web.listen-address {{ api_interface_address | put_address_in_context('url') }}:{{ prometheus_haproxy_exporter_port }}{% if prometheus_haproxy_exporter_cmdline_extras %} {{ prometheus_haproxy_exporter_cmdline_extras }}{% endif %}",
     "config_files": [],
     "permissions": [
         {

--- a/ansible/roles/prometheus/templates/prometheus-memcached-exporter.json.j2
+++ b/ansible/roles/prometheus/templates/prometheus-memcached-exporter.json.j2
@@ -1,5 +1,5 @@
 {
-    "command": "/opt/memcached_exporter/memcached_exporter --web.listen-address {{ api_interface_address | put_address_in_context('url') }}:{{ prometheus_memcached_exporter_port }} --memcached.address {{ api_interface_address | put_address_in_context('url') }}:{{ memcached_port }}",
+    "command": "/opt/memcached_exporter/memcached_exporter --web.listen-address {{ api_interface_address | put_address_in_context('url') }}:{{ prometheus_memcached_exporter_port }} --memcached.address {{ api_interface_address | put_address_in_context('url') }}:{{ memcached_port }}{% if prometheus_memcached_exporter_cmdline_extras %} {{ prometheus_memcached_exporter_cmdline_extras }}{% endif %}",
     "config_files": [],
     "permissions": [
         {

--- a/ansible/roles/prometheus/templates/prometheus-mysqld-exporter.json.j2
+++ b/ansible/roles/prometheus/templates/prometheus-mysqld-exporter.json.j2
@@ -1,5 +1,5 @@
 {
-    "command": "/opt/mysqld_exporter/mysqld_exporter --config.my-cnf /etc/prometheus/my.cnf --web.listen-address {{ api_interface_address | put_address_in_context('url') }}:{{ prometheus_mysqld_exporter_port }}",
+    "command": "/opt/mysqld_exporter/mysqld_exporter --config.my-cnf /etc/prometheus/my.cnf --web.listen-address {{ api_interface_address | put_address_in_context('url') }}:{{ prometheus_mysqld_exporter_port }}{% if prometheus_mysqld_exporter_cmdline_extras %} {{ prometheus_mysqld_exporter_cmdline_extras }}{% endif %}",
     "config_files": [
         {
             "source": "{{ container_config_directory }}/my.cnf",

--- a/ansible/roles/prometheus/templates/prometheus-node-exporter.json.j2
+++ b/ansible/roles/prometheus/templates/prometheus-node-exporter.json.j2
@@ -1,5 +1,5 @@
 {
-    "command": "/opt/node_exporter/node_exporter --path.procfs /host/proc --path.sysfs /host/sys --path.rootfs /host --web.listen-address {{ api_interface_address | put_address_in_context('url') }}:{{ prometheus_node_exporter_port }}",
+    "command": "/opt/node_exporter/node_exporter --path.procfs /host/proc --path.sysfs /host/sys --path.rootfs /host --web.listen-address {{ api_interface_address | put_address_in_context('url') }}:{{ prometheus_node_exporter_port }}{% if prometheus_node_exporter_cmdline_extras %} {{ prometheus_node_exporter_cmdline_extras }}{% endif %}",
     "config_files": [],
     "permissions": [
         {

--- a/ansible/roles/prometheus/templates/prometheus-openstack-exporter.json.j2
+++ b/ansible/roles/prometheus/templates/prometheus-openstack-exporter.json.j2
@@ -1,5 +1,5 @@
 {
-    "command": "/opt/openstack-exporter/openstack-exporter --endpoint-type={{ prometheus_openstack_exporter_endpoint_type }} --os-client-config=/etc/openstack/clouds.yml --web.listen-address={{ api_interface_address | put_address_in_context('url') }}:{{ prometheus_openstack_exporter_port }} default {{ prometheus_openstack_exporter_disabled_items }}",
+    "command": "/opt/openstack-exporter/openstack-exporter --endpoint-type={{ prometheus_openstack_exporter_endpoint_type }} --os-client-config=/etc/openstack/clouds.yml --web.listen-address={{ api_interface_address | put_address_in_context('url') }}:{{ prometheus_openstack_exporter_port }} default {{ prometheus_openstack_exporter_disabled_items }}{% if prometheus_openstack_exporter_cmdline_extras %} {{ prometheus_openstack_exporter_cmdline_extras }}{% endif %}",
     "config_files": [
         {
             "source": "{{ container_config_directory }}/clouds.yml",

--- a/etc/kolla/globals.yml
+++ b/etc/kolla/globals.yml
@@ -729,6 +729,15 @@
 # and container labels are not exposed to reduce time series cardinality.
 #prometheus_cadvisor_cmdline_extras: "--docker_only --store_container_labels=false --disable_metrics=percpu,referenced_memory,cpu_topology,resctrl,udp,advtcp,sched,hugetlb,memory_numa,tcp,process"
 
+# Extra parameters passed to Prometheus exporters.
+#prometheus_blackbox_exporter_cmdline_extras:
+#prometheus_elasticsearch_exporter_cmdline_extras:
+#prometheus_haproxy_exporter_cmdline_extras:
+#prometheus_memcached_exporter_cmdline_extras:
+#prometheus_mysqld_exporter_cmdline_extras:
+#prometheus_node_exporter_cmdline_extras:
+#prometheus_openstack_exporter_cmdline_extras:
+
 # Example of setting endpoints for prometheus ceph mgr exporter.
 # You should add all ceph mgr's in your external ceph deployment.
 #prometheus_ceph_mgr_exporter_endpoints:

--- a/releasenotes/notes/prometheus-exporters-cmdline-extras-033299871badd2c6.yaml
+++ b/releasenotes/notes/prometheus-exporters-cmdline-extras-033299871badd2c6.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    Adds variables to define extra command-line parameters to be passed to
+    Prometheus exporters:
+
+    * ``prometheus_blackbox_exporter_cmdline_extras``
+    * ``prometheus_elasticsearch_exporter_cmdline_extras``
+    * ``prometheus_haproxy_exporter_cmdline_extras``
+    * ``prometheus_memcached_exporter_cmdline_extras``
+    * ``prometheus_mysqld_exporter_cmdline_extras``
+    * ``prometheus_node_exporter_cmdline_extras``
+    * ``prometheus_openstack_exporter_cmdline_extras``


### PR DESCRIPTION
The following variables are added:

* prometheus_blackbox_exporter_cmdline_extras
* prometheus_elasticsearch_exporter_cmdline_extras
* prometheus_haproxy_exporter_cmdline_extras
* prometheus_memcached_exporter_cmdline_extras
* prometheus_mysqld_exporter_cmdline_extras
* prometheus_node_exporter_cmdline_extras
* prometheus_openstack_exporter_cmdline_extras

Change-Id: I5da2031b9367115384045775c515628e2acb1aa4
(cherry picked from commit dcba8297929ee70e2b75d1705e40e60a6b5b2302)