### PR TITLE
backport: designate: Allow to disable notifications

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1004,6 +1004,9 @@ designate_admin_endpoint: "{{ admin_protocol }}://{{ designate_internal_fqdn | p
 designate_internal_endpoint: "{{ internal_protocol }}://{{ designate_internal_fqdn | put_address_in_context('url') }}:{{ designate_api_port }}"
 designate_public_endpoint: "{{ public_protocol }}://{{ designate_external_fqdn | put_address_in_context('url') }}:{{ designate_api_port }}"
 
+designate_enable_notifications_sink: "yes"
+designate_notifications_topic_name: "notifications_designate"
+
 #######################
 # Neutron options
 #######################

--- a/ansible/roles/designate/defaults/main.yml
+++ b/ansible/roles/designate/defaults/main.yml
@@ -64,7 +64,7 @@ designate_services:
   designate-sink:
     container_name: designate_sink
     group: designate-sink
-    enabled: true
+    enabled: "{{ designate_enable_notifications_sink | bool }}"
     image: "{{ designate_sink_image_full }}"
     volumes: "{{ designate_sink_default_volumes + designate_sink_extra_volumes }}"
     dimensions: "{{ designate_sink_dimensions }}"
@@ -310,11 +310,9 @@ designate_infoblox_ns_group: ""
 ####################
 # Notifications
 ####################
-designate_notifications_topic_name: "notifications_designate"
-
 designate_notification_topics:
   - name: "{{ designate_notifications_topic_name }}"
-    enabled: True
+    enabled: "{{ designate_enable_notifications_sink | bool }}"
 
 designate_enabled_notification_topics: "{{ designate_notification_topics | selectattr('enabled', 'equalto', true) | list }}"
 

--- a/ansible/roles/designate/templates/designate.conf.j2
+++ b/ansible/roles/designate/templates/designate.conf.j2
@@ -36,10 +36,6 @@ memcache_security_strategy = ENCRYPT
 memcache_secret_key = {{ memcache_secret_key }}
 memcached_servers = {% for host in groups['memcached'] %}{{ 'api' | kolla_address(host) | put_address_in_context('memcache') }}:{{ memcached_port }}{% if not loop.last %},{% endif %}{% endfor %}
 
-[service:sink]
-enabled_notification_handlers = nova_fixed, neutron_floatingip
-workers = {{ openstack_service_workers }}
-
 {% if service_name == 'designate-mdns' %}
 [service:mdns]
 listen = {{ 'dns' | kolla_address | put_address_in_context('url') }}:{{ designate_mdns_port }}
@@ -63,6 +59,11 @@ connection = mysql+pymysql://{{ designate_database_user }}:{{ designate_database
 max_retries = 10
 idle_timeout = 3600
 
+{% if service_name == 'designate-sink' and designate_enable_notifications_sink | bool %}
+[service:sink]
+enabled_notification_handlers = nova_fixed, neutron_floatingip
+workers = {{ openstack_service_workers }}
+
 [handler:nova_fixed]
 #NOTE: zone_id must be manually filled an ID from openstack zone list
 zone_id =
@@ -80,6 +81,7 @@ zone_id =
 notification_topics = {{ designate_notifications_topic_name }}
 control_exchange = neutron
 formatv4 = '%(octet0)s-%(octet1)s-%(octet2)s-%(octet3)s.%(zone)s'
+{% endif %}
 
 [oslo_messaging_notifications]
 transport_url = {{ notify_transport_url }}

--- a/ansible/roles/neutron/defaults/main.yml
+++ b/ansible/roles/neutron/defaults/main.yml
@@ -650,8 +650,8 @@ neutron_service_plugins: "{{ service_plugins | selectattr('enabled', 'equalto', 
 neutron_notification_topics:
   - name: notifications
     enabled: "{{ enable_ceilometer | bool or enable_neutron_infoblox_ipam_agent | bool }}"
-  - name: notifications_designate
-    enabled: "{{ enable_designate | bool }}"
+  - name: "{{ designate_notifications_topic_name }}"
+    enabled: "{{ designate_enable_notifications_sink | bool }}"
   - name: vitrage_notifications
     enabled: "{{ enable_vitrage | bool }}"
 

--- a/ansible/roles/nova-cell/defaults/main.yml
+++ b/ansible/roles/nova-cell/defaults/main.yml
@@ -501,8 +501,8 @@ nova_compute_registration_fatal: false
 nova_notification_topics:
   - name: notifications
     enabled: "{{ enable_ceilometer | bool or enable_neutron_infoblox_ipam_agent | bool }}"
-  - name: notifications_designate
-    enabled: "{{ enable_designate | bool }}"
+  - name: "{{ designate_notifications_topic_name }}"
+    enabled: "{{ designate_enable_notifications_sink | bool }}"
   - name: vitrage_notifications
     enabled: "{{ enable_vitrage | bool }}"
 

--- a/ansible/roles/nova/defaults/main.yml
+++ b/ansible/roles/nova/defaults/main.yml
@@ -223,8 +223,8 @@ nova_ks_users:
 nova_notification_topics:
   - name: notifications
     enabled: "{{ enable_ceilometer | bool or enable_neutron_infoblox_ipam_agent | bool }}"
-  - name: notifications_designate
-    enabled: "{{ enable_designate | bool }}"
+  - name: "{{ designate_notifications_topic_name }}"
+    enabled: "{{ designate_enable_notifications_sink | bool }}"
   - name: vitrage_notifications
     enabled: "{{ enable_vitrage | bool }}"
 

--- a/ansible/roles/placement/defaults/main.yml
+++ b/ansible/roles/placement/defaults/main.yml
@@ -83,8 +83,6 @@ openstack_placement_auth: "{{ openstack_auth }}"
 placement_notification_topics:
   - name: notifications
     enabled: "{{ enable_ceilometer | bool or enable_neutron_infoblox_ipam_agent | bool }}"
-  - name: notifications_designate
-    enabled: "{{ enable_designate | bool }}"
 
 placement_enabled_notification_topics: "{{ placement_notification_topics | selectattr('enabled', 'equalto', true) | list }}"
 

--- a/releasenotes/notes/designate_notifications-5c87ca79a1a9125e.yaml
+++ b/releasenotes/notes/designate_notifications-5c87ca79a1a9125e.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Allow to disable Designate Sink service (and notifications to/from it) by
+    setting ``designate_enable_notifications_sink`` to ``no``.


### PR DESCRIPTION
Designate sink is an optional service that consumes notifications, users should have an option to disable it when they don't use them.

Change-Id: I1d5465d9845aea94cff39ff5158cd8b1dccc4834