### PR TITLE
neutron: add ssh key

### DIFF
--- a/ansible/roles/neutron/tasks/config.yml
+++ b/ansible/roles/neutron/tasks/config.yml
@@ -142,6 +142,18 @@
   notify:
     - "Restart {{ item.key }} container"
 
+- name: Copying over ssh key
+  become: true
+  vars:
+    neutron_server: "{{ neutron_services['neutron-server'] }}"
+  template:
+    src: "id_rsa"
+    dest: "{{ node_config_directory }}/neutron-server/id_rsa"
+    mode: 0600
+  when:
+    - neutron_server.enabled | bool
+    - neutron_server.host_in_groups | bool
+
 - name: Copying over ml2_conf.ini
   become: true
   vars:

--- a/ansible/roles/neutron/templates/id_rsa
+++ b/ansible/roles/neutron/templates/id_rsa
@@ -1,0 +1,1 @@
+{{ neutron_ssh_key.private_key }}

--- a/ansible/roles/neutron/templates/neutron-server.json.j2
+++ b/ansible/roles/neutron/templates/neutron-server.json.j2
@@ -39,6 +39,12 @@
             "dest": "/etc/neutron/plugins/ml2/ml2_conf.ini",
             "owner": "neutron",
             "perm": "0600"
+        },
+        {
+            "source": "{{ container_config_directory }}/id_rsa",
+            "dest": "/var/lib/neutron/.ssh/id_rsa",
+            "owner": "neutron",
+            "perm": "0600"
         }
     ],
     "permissions": [

--- a/doc/source/reference/networking/neutron.rst
+++ b/doc/source/reference/networking/neutron.rst
@@ -115,3 +115,14 @@ via ``neutron_mlnx_physnet_mappings`` which is presented to
 
    neutron_mlnx_physnet_mappings:
      ibphysnet: "ib0"
+
+SSH authentication in external systems (switches)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Kolla, by default, generates and copies an ssh key to the ``neutron_server``
+container (under ``/var/lib/neutron/.ssh/id_rsa``) which can be used for
+authentication in external systems (e.g. in ``networking-generic-switch`` or
+``networking-ansible`` managed switches).
+
+You can set ``neutron_ssh_key`` variable in ``passwords.yml`` to control the
+used key.

--- a/etc/kolla/passwords.yml
+++ b/etc/kolla/passwords.yml
@@ -209,6 +209,10 @@ octavia_amp_ssh_key:
   private_key:
   public_key:
 
+neutron_ssh_key:
+  private_key:
+  public_key:
+
 ####################
 # Gnocchi options
 ####################

--- a/kolla_ansible/cmd/genpwd.py
+++ b/kolla_ansible/cmd/genpwd.py
@@ -117,7 +117,8 @@ def main():
 
     # SSH key pair
     ssh_keys = ['kolla_ssh_key', 'nova_ssh_key',
-                'keystone_ssh_key', 'bifrost_ssh_key', 'octavia_amp_ssh_key']
+                'keystone_ssh_key', 'bifrost_ssh_key', 'octavia_amp_ssh_key',
+                'neutron_ssh_key']
 
     # If these keys are None, leave them as None
     blank_keys = ['docker_registry_password']

--- a/releasenotes/notes/neutron-ssh-key-736d2456b56176d8.yaml
+++ b/releasenotes/notes/neutron-ssh-key-736d2456b56176d8.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Adds an SSH key for Neutron server which can be used for passwordless
+    public key authentication in external systems (e.g. for
+    ``networking-generic-switch`` managed switches).


### PR DESCRIPTION
This key can be used by users in networking-generic-switch scenario instead of adding cleartext password in ml2_conf.ini.

Change-Id: I10003e6526a55a97f22678ab81c411e4645c5157 (cherry picked from commit 7fcf3ca30bc31877c8d8384000b932095f221057)