### PR TITLE
backport to stackhpc/wallaby: designate: Enable Sink only when designate is enabled

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1004,7 +1004,7 @@ designate_admin_endpoint: "{{ admin_protocol }}://{{ designate_internal_fqdn | p
 designate_internal_endpoint: "{{ internal_protocol }}://{{ designate_internal_fqdn | put_address_in_context('url') }}:{{ designate_api_port }}"
 designate_public_endpoint: "{{ public_protocol }}://{{ designate_external_fqdn | put_address_in_context('url') }}:{{ designate_api_port }}"
 
-designate_enable_notifications_sink: "yes"
+designate_enable_notifications_sink: "{{ enable_designate | bool }}"
 designate_notifications_topic_name: "notifications_designate"
 
 #######################


### PR DESCRIPTION
A recent patch [1] enabled sink related changes to nova/neutron even when designate is not enabled. This patch fixes that.

[1] - https://review.opendev.org/c/openstack/kolla-ansible/+/802301

Change-Id: I6d76f342a7cdbcc61d1522689ea489b60353adcd (cherry picked from commit b4ff2ad9819f9934881eddb9da04481994a59288)