### PR TITLE
[stackhpc/yoga] Support specifying Nova compute provider config

### DIFF
--- a/ansible/roles/nova-cell/tasks/config.yml
+++ b/ansible/roles/nova-cell/tasks/config.yml
@@ -74,6 +74,21 @@
   notify:
     - "Restart {{ item.key }} container"
 
+- name: Copying over Nova compute provider config
+  become: true
+  vars:
+    service: "{{ nova_cell_services['nova-compute'] }}"
+  copy:
+    content: "{{ nova_cell_compute_provider_config | to_nice_yaml(indent=2) }}"
+    dest: "{{ node_config_directory }}/nova-compute/provider_config.yaml"
+    mode: "0660"
+  when:
+    - inventory_hostname in groups[service.group]
+    - nova_cell_compute_provider_config is defined
+    - service.enabled | bool
+  notify:
+    - Restart nova-compute container
+
 - name: Copying over libvirt configuration
   become: true
   vars:

--- a/ansible/roles/nova-cell/templates/nova-compute.json.j2
+++ b/ansible/roles/nova-cell/templates/nova-compute.json.j2
@@ -61,6 +61,12 @@
             "dest": "/var/lib/nova/.config/libvirt/auth.conf",
             "owner": "nova",
             "perm": "0600"
+        }{% endif %}{% if nova_cell_compute_provider_config is defined %},
+        {
+            "source": "{{ container_config_directory }}/provider_config.yaml",
+            "dest": "/etc/nova/provider_config/provider_config.yaml",
+            "owner": "nova",
+            "perm": "0600"
         }{% endif %}
     ],
     "permissions": [

--- a/doc/source/reference/compute/nova-guide.rst
+++ b/doc/source/reference/compute/nova-guide.rst
@@ -79,3 +79,51 @@ behaviour is useful at scale, where failures are more frequent.
 
 Alternatively, to fail all hosts in a cell when any compute service fails
 to register, set ``nova_compute_registration_fatal`` to ``true``.
+
+Managing resource providers via config files
+============================================
+
+In the Victoria cycle Nova merged support for managing resource providers
+via :nova-doc:`configuration files <admin/managing-resource-providers>`.
+
+Kolla Ansible limits the use of this feature to a single config file per
+Nova Compute service, which is defined via Ansible inventory group/host vars.
+The reason for doing this is to encourage users to configure each compute
+service individually, so that when further resources are added, existing
+compute services do not need to be restarted.
+
+For example, a user wanting to configure a compute resource with GPUs for
+a specific host may add the following file to host_vars:
+
+.. code-block:: console
+
+    [host_vars]$ cat gpu_compute_0001
+    nova_cell_compute_provider_config:
+      meta:
+        schema_version: '1.0'
+      providers:
+        - identification:
+            name: $COMPUTE_NODE
+          inventories:
+            additional:
+              - CUSTOM_GPU:
+                  total: 8
+                  reserved: 0
+                  min_unit: 1
+                  max_unit: 1
+                  step_size: 1
+                  allocation_ratio: 1.0
+
+A similar approach can be used with group vars to cover more than one machine.
+
+Since a badly formatted file will prevent the Nova Compute service from
+starting, it should first be validated as described in the
+:nova-doc:`documentation <admin/managing-resource-providers>`.
+The Nova Compute service can then be reconfigured to apply the change.
+
+To remove the resource provider configuration, it is simplest to leave the
+group/host vars in place without specifying any inventory or traits. This will
+effectively remove the configuration when the Nova Compute service is restarted.
+If you choose to undefine `nova_cell_compute_provider_config` on a host, you must
+manually remove the generated config from inside the container, or recreate the
+container.

--- a/releasenotes/notes/feature-compute-provider-config-9a17105e5c5b048e.yaml
+++ b/releasenotes/notes/feature-compute-provider-config-9a17105e5c5b048e.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds support for managing resource providers via `config files
+    <https://docs.openstack.org/nova/latest/admin/managing-resource-providers.html>`__.


### PR DESCRIPTION
In the Victoria cycle, Nova merged improved support for managing resource providers:
https://review.opendev.org/q/topic:bp%252Fprovider-config-file

See the blueprint for more details:
https://docs.openstack.org/nova/latest/admin/managing-resource-providers.html

This change allows us to copy the necessary configuration.

Change-Id: I0a3caaad73bc6fe27380e7f6bf6b792aca51c84c (cherry picked from commit 522c3291cd6a405e8a0df7f7c8ee9846ae29727f)