### PR TITLE
[wallaby] Introduce variables for cinder backend names

### DIFF
--- a/ansible/roles/cinder/defaults/main.yml
+++ b/ansible/roles/cinder/defaults/main.yml
@@ -215,18 +215,25 @@ cinder_rpc_version_startup_delay: 30
 # Cinder
 ####################
 cinder_backends:
-  - name: "rbd-1"
+  - name: "{{ cinder_backend_ceph_name }}"
     enabled: "{{ cinder_backend_ceph | bool }}"
-  - name: "lvm-1"
+  - name: "{{ cinder_backend_lvm_name }}"
     enabled: "{{ enable_cinder_backend_lvm | bool }}"
-  - name: "nfs-1"
+  - name: "{{ cinder_backend_nfs_name }}"
     enabled: "{{ enable_cinder_backend_nfs | bool }}"
-  - name: "hnas-nfs"
+  - name: "{{ cinder_backend_hnas_nfs_name }}"
     enabled: "{{ enable_cinder_backend_hnas_nfs | bool }}"
-  - name: "vmwarevc-vmdk"
+  - name: "{{ cinder_backend_vmwarevc_vmdk_name }}"
     enabled: "{{ cinder_backend_vmwarevc_vmdk | bool }}"
-  - name: "QuobyteHD"
+  - name: "{{ cinder_backend_quobyte_name }}"
     enabled: "{{ enable_cinder_backend_quobyte | bool }}"
+
+cinder_backend_ceph_name: "rbd-1"
+cinder_backend_lvm_name: "lvm-1"
+cinder_backend_nfs_name: "nfs-1"
+cinder_backend_hnas_nfs_name: "hnas-nfs"
+cinder_backend_vmwarevc_vmdk_name: "vmwarevc-vmdk"
+cinder_backend_quobyte_name: "QuobyteHD"
 
 skip_cinder_backend_check: False
 

--- a/ansible/roles/cinder/templates/cinder.conf.j2
+++ b/ansible/roles/cinder/templates/cinder.conf.j2
@@ -126,18 +126,18 @@ lock_path = /var/lib/cinder/tmp
 
 
 {% if enable_cinder_backend_lvm | bool %}
-[lvm-1]
+[{{ cinder_backend_lvm_name }}]
 volume_group = {{ cinder_volume_group }}
 volume_driver = cinder.volume.drivers.lvm.LVMVolumeDriver
-volume_backend_name = lvm-1
+volume_backend_name = {{ cinder_backend_lvm_name }}
 target_helper = {{ cinder_target_helper }}
 target_protocol = iscsi
 {% endif %}
 
 {% if cinder_backend_ceph | bool %}
-[rbd-1]
+[{{ cinder_backend_ceph_name }}]
 volume_driver = cinder.volume.drivers.rbd.RBDDriver
-volume_backend_name = rbd-1
+volume_backend_name = {{ cinder_backend_ceph_name }}
 rbd_pool = {{ ceph_cinder_pool_name }}
 rbd_ceph_conf = /etc/ceph/ceph.conf
 rbd_flatten_volume_from_snapshot = false
@@ -150,9 +150,9 @@ report_discard_supported = True
 {% endif %}
 
 {% if enable_cinder_backend_nfs | bool %}
-[nfs-1]
+[{{ cinder_backend_nfs_name }}]
 volume_driver = cinder.volume.drivers.nfs.NfsDriver
-volume_backend_name = nfs-1
+volume_backend_name = {{ cinder_backend_nfs_name }}
 nfs_shares_config = /etc/cinder/nfs_shares
 nfs_snapshot_support = True
 nas_secure_file_permissions = False
@@ -160,7 +160,7 @@ nas_secure_file_operations = False
 {% endif %}
 
 {% if enable_cinder_backend_hnas_nfs | bool %}
-[hnas-nfs]
+[{{ cinder_backend_hnas_nfs_name }}]
 volume_driver = cinder.volume.drivers.hitachi.hnas_nfs.HNASNFSDriver
 nfs_shares_config = /home/cinder/nfs_shares
 volume_backend_name = {{ hnas_nfs_backend }}
@@ -173,8 +173,8 @@ hnas_svc0_hdp = {{ hnas_nfs_svc0_hdp }}
 {% endif %}
 
 {% if cinder_backend_vmwarevc_vmdk | bool %}
-[vmwarevc-vmdk]
-volume_backend_name=vmwarevc-vmdk
+[{{ cinder_backend_vmwarevc_vmdk_name }}]
+volume_backend_name={{ cinder_backend_vmwarevc_vmdk_name }}
 volume_driver = cinder.volume.drivers.vmware.vmdk.VMwareVcVmdkDriver
 vmware_host_ip = {{ vmware_vcenter_host_ip }}
 vmware_host_username = {{ vmware_vcenter_host_username }}
@@ -184,7 +184,7 @@ vmware_insecure = True
 {% endif %}
 
 {% if enable_cinder_backend_quobyte | bool %}
-[QuobyteHD]
+[{{ cinder_backend_quobyte_name }}]
 volume_driver = cinder.volume.drivers.quobyte.QuobyteDriver
 quobyte_volume_url = quobyte://{{ quobyte_storage_host }}/{{ quobyte_storage_volume }}
 {% endif %}

--- a/doc/source/reference/storage/cinder-guide.rst
+++ b/doc/source/reference/storage/cinder-guide.rst
@@ -200,3 +200,55 @@ in Kolla, the following parameter must be specified in ``globals.yml``:
 
 All configuration for custom NFS backend should be performed
 via ``cinder.conf`` in config overrides directory.
+
+Customizing backend names in cinder.conf
+----------------------------------------
+
+.. note::
+
+   This is an advanced configuration option. You cannot change these variables
+   if you already have volumes that use the old name without additional steps.
+   Sensible defaults exist out of the box.
+
+The following variables are available to customise the default backend name
+that appears in cinder.conf:
+
+.. list-table:: Variables to customize backend name
+   :widths: 50 25 25
+   :header-rows: 1
+
+   * - Driver
+     - Variable
+     - Default value
+   * - Ceph
+     - cinder_backend_ceph_name
+     - rbd-1
+   * - Logical Volume Manager (LVM)
+     - cinder_backend_lvm_name
+     - lvm-1
+   * - Network File System (NFS)
+     - cinder_backend_nfs_name
+     - nfs-1
+   * - Hitachi NAS Platform NFS
+     - cinder_backend_hnas_nfs_name
+     - hnas-nfs
+   * - VMware Virtual Machine Disk File
+     - cinder_backend_vmwarevc_vmdk_name
+     - vmwarevc-vmdk
+   * - VMware VStorage (Object Storage)
+     - cinder_backend_vmware_vstorage_object_name
+     - vmware-vstorage-object
+   * - Quobyte Storage for OpenStack
+     - cinder_backend_quobyte_name
+     - QuobyteHD
+   * - Pure Storage FlashArray for OpenStack (iSCSI)
+     - cinder_backend_pure_iscsi_name
+     - Pure-FlashArray-iscsi
+   * - Pure Storage FlashArray for OpenStack
+     - cinder_backend_pure_fc_name
+     - Pure-FlashArray-fc
+
+These are the names you use when
+`configuring <https://docs.openstack.org/cinder/latest/admin/multi-backend.html#volume-type>`_
+``volume_backend_name`` on cinder volume types. It can sometimes be
+useful to provide a more descriptive name.

--- a/releasenotes/notes/add-cinder-backend-name-variables-edcc4a675ca06c0c.yaml
+++ b/releasenotes/notes/add-cinder-backend-name-variables-edcc4a675ca06c0c.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Adds a set of variables to control the cinder backend name, as used in
+    cinder.conf. This is the name you use when setting the volume_backend_name
+    property on volume types. Details are in the
+    `cinder guide <https://docs.openstack.org/kolla-ansible/latest/reference/storage/cinder-guide.html>`_
+    section of the documentation.


### PR DESCRIPTION
This allows you to use a more descriptive name if you desire. For example, when using cinder with multiple ceph backends, rbd-1, doesn't convey much information. You could include location, disk technology, etc. in the name.

Change-Id: Icfdc2e5726fec8b645d6c2c63391a13c31f2ce9a (cherry picked from commit 0fe8010c887550a41774ec57d3628c626a8eb3be)

Conflicts: ansible/roles/cinder/defaults/main.yml
  ansible/roles/cinder/templates/cinder.conf.j2
Change-Id: Id7e004386b99102eb022aa1fa3e6130fd2a7153b