### PR TITLE
Stop firewalld config during kolla genconfig

### DIFF
--- a/ansible/roles/haproxy-config/tasks/main.yml
+++ b/ansible/roles/haproxy-config/tasks/main.yml
@@ -36,6 +36,7 @@
     - item.value.port is defined
     - item.value.external | default('false') | bool
     - enable_external_api_firewalld | bool
+    - kolla_action != "config"
   with_dict: "{{ project_services | extract_haproxy_services }}"
   notify:
     - "Reload firewalld"

--- a/releasenotes/notes/stop-firewalld-being-configured-during-genconfig-21e3fa4b9a6c677d.yaml
+++ b/releasenotes/notes/stop-firewalld-being-configured-during-genconfig-21e3fa4b9a6c677d.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Prevent haproxy-config role from attempting to configure firewalld
+    during a kolla-ansible genconfig.
+    `LP#2002522 <https://launchpad.net/bugs/2002522>`__


### PR DESCRIPTION
Prevent the haproxy-config role from attempting to modify firewalld when running kolla-ansible genconfig.

Closes-Bug: #2002522
Change-Id: Ie8a524cc944aa8cb9cf0999b1b8da79f30b40092 (cherry picked from commit 86870bd7f84f2eeed14a7c0c24688c93b8d2ac1c)