### PR TITLE
Temporarily set kombu_reconnect_delay to 0.1

### DIFF
--- a/ansible/roles/aodh/templates/aodh.conf.j2
+++ b/ansible/roles/aodh/templates/aodh.conf.j2
@@ -60,6 +60,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = {{ service_name == 'aodh-api' }}
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/barbican/templates/barbican.conf.j2
+++ b/ansible/roles/barbican/templates/barbican.conf.j2
@@ -78,6 +78,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = false
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/blazar/templates/blazar.conf.j2
+++ b/ansible/roles/blazar/templates/blazar.conf.j2
@@ -54,6 +54,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = false
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/ceilometer/templates/ceilometer.conf.j2
+++ b/ansible/roles/ceilometer/templates/ceilometer.conf.j2
@@ -36,6 +36,7 @@ ca_file = /etc/ceilometer/vmware_ca
 transport_url = {{ notify_transport_url }}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = false
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/cinder/templates/cinder.conf.j2
+++ b/ansible/roles/cinder/templates/cinder.conf.j2
@@ -70,6 +70,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = {{ service_name == 'cinder-api' }}
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/cloudkitty/templates/cloudkitty.conf.j2
+++ b/ansible/roles/cloudkitty/templates/cloudkitty.conf.j2
@@ -44,6 +44,7 @@ policy_file = {{ cloudkitty_policy_file }}
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = {{ service_name == 'cloudkitty-api' }}
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/cyborg/templates/cyborg.conf.j2
+++ b/ansible/roles/cyborg/templates/cyborg.conf.j2
@@ -57,6 +57,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = false
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/designate/templates/designate.conf.j2
+++ b/ansible/roles/designate/templates/designate.conf.j2
@@ -92,6 +92,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = false
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/glance/templates/glance-api.conf.j2
+++ b/ansible/roles/glance/templates/glance-api.conf.j2
@@ -125,6 +125,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = false
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/heat/templates/heat.conf.j2
+++ b/ansible/roles/heat/templates/heat.conf.j2
@@ -86,6 +86,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = {{ service_name == 'heat-api' or service_name == 'heat-api-cfn' }}
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/ironic/templates/ironic-inspector.conf.j2
+++ b/ansible/roles/ironic/templates/ironic-inspector.conf.j2
@@ -13,6 +13,7 @@ transport_url = {{ rpc_transport_url }}
 transport_url = {{ notify_transport_url }}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = true
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/ironic/templates/ironic.conf.j2
+++ b/ansible/roles/ironic/templates/ironic.conf.j2
@@ -28,6 +28,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = {{ service_name == 'ironic-api' }}
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/keystone/templates/keystone.conf.j2
+++ b/ansible/roles/keystone/templates/keystone.conf.j2
@@ -60,6 +60,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = {{ service_name == 'keystone' }}
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/magnum/templates/magnum.conf.j2
+++ b/ansible/roles/magnum/templates/magnum.conf.j2
@@ -122,6 +122,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = false
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/manila/templates/manila.conf.j2
+++ b/ansible/roles/manila/templates/manila.conf.j2
@@ -56,6 +56,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = false
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/masakari/templates/masakari.conf.j2
+++ b/ansible/roles/masakari/templates/masakari.conf.j2
@@ -50,6 +50,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = {{ service_name == 'masakari-api' }}
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/mistral/templates/mistral.conf.j2
+++ b/ansible/roles/mistral/templates/mistral.conf.j2
@@ -72,6 +72,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = false
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/murano/templates/murano.conf.j2
+++ b/ansible/roles/murano/templates/murano.conf.j2
@@ -61,6 +61,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = false
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/neutron/templates/neutron.conf.j2
+++ b/ansible/roles/neutron/templates/neutron.conf.j2
@@ -137,6 +137,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = false
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/nova-cell/templates/nova.conf.j2
+++ b/ansible/roles/nova-cell/templates/nova.conf.j2
@@ -185,6 +185,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = false
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/nova/templates/nova.conf.j2
+++ b/ansible/roles/nova/templates/nova.conf.j2
@@ -138,6 +138,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = {{ service_name == 'nova-api' }}
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/octavia/templates/octavia.conf.j2
+++ b/ansible/roles/octavia/templates/octavia.conf.j2
@@ -122,6 +122,7 @@ rpc_thread_pool_size = 2
 transport_url = {{ notify_transport_url }}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = {{ service_name == 'octavia-api' }}
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/sahara/templates/sahara.conf.j2
+++ b/ansible/roles/sahara/templates/sahara.conf.j2
@@ -40,6 +40,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = false
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/senlin/templates/senlin.conf.j2
+++ b/ansible/roles/senlin/templates/senlin.conf.j2
@@ -68,6 +68,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = false
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/solum/templates/solum.conf.j2
+++ b/ansible/roles/solum/templates/solum.conf.j2
@@ -67,6 +67,7 @@ memcached_servers = {% for host in groups['memcached'] %}{{ 'api' | kolla_addres
 transport_url = {{ notify_transport_url }}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = false
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/tacker/templates/tacker.conf.j2
+++ b/ansible/roles/tacker/templates/tacker.conf.j2
@@ -68,6 +68,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = false
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/trove/templates/trove.conf.j2
+++ b/ansible/roles/trove/templates/trove.conf.j2
@@ -71,6 +71,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = false
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/vitrage/templates/vitrage.conf.j2
+++ b/ansible/roles/vitrage/templates/vitrage.conf.j2
@@ -74,6 +74,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = {{ service_name == 'vitrage-api' }}
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/watcher/templates/watcher.conf.j2
+++ b/ansible/roles/watcher/templates/watcher.conf.j2
@@ -59,6 +59,7 @@ driver = noop
 {% endif %}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = false
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true

--- a/ansible/roles/zun/templates/zun.conf.j2
+++ b/ansible/roles/zun/templates/zun.conf.j2
@@ -129,6 +129,7 @@ docker_remote_api_port = 2375
 cni_daemon_port = {{ zun_cni_daemon_port }}
 
 [oslo_messaging_rabbit]
+kombu_reconnect_delay = 0.1
 heartbeat_in_pthread = {{ service_name == 'zun-api' }}
 {% if om_enable_rabbitmq_tls | bool %}
 ssl = true


### PR DESCRIPTION
Temporarily set the value [oslo_messaging_rabbit] kombu_reconnect_delay to 0.1 in all services which use RabbitMQ. Fixes the "timeout waiting for reply..." errors seen, which cause VMs to fail building when a RabbitMQ node is down. See bug:
https://bugs.launchpad.net/cloud-archive/+bug/1993149

This patch is temporary while the upstream patche(s) to oslo.messaging are still in progress. It should be reverted once the bug is fixed upstream. See:
https://review.opendev.org/c/openstack/oslo.messaging/+/866617 https://review.opendev.org/c/openstack/oslo.messaging/+/866616