### PR TITLE
Prevent libvirtd reload when only generating config

### DIFF
--- a/ansible/roles/nova-cell/handlers/main.yml
+++ b/ansible/roles/nova-cell/handlers/main.yml
@@ -133,6 +133,8 @@
   service:
     name: libvirtd
     state: reloaded
+  when:
+    - kolla_action != "config"
 
 - name: Restart nova-compute container
   vars:


### PR DESCRIPTION
When generating config, we do not want to restart any services.

TrivialFix

Change-Id: Ice13759c406ff7cec91c9d740b0e0c43eda99510