### PR TITLE
Adds the neutron_service_limit option

### DIFF
--- a/ansible/roles/neutron/defaults/main.yml
+++ b/ansible/roles/neutron/defaults/main.yml
@@ -3,7 +3,7 @@ neutron_services:
   neutron-server:
     container_name: "neutron_server"
     image: "{{ neutron_server_image_full }}"
-    enabled: true
+    enabled: "{{ neutron_service_limit == 'all' or 'neutron-server' in _neutron_service_limit }}"
     group: "neutron-server"
     host_in_groups: "{{ inventory_hostname in groups['neutron-server'] }}"
     volumes: "{{ neutron_server_default_volumes + neutron_server_extra_volumes }}"
@@ -25,7 +25,7 @@ neutron_services:
   neutron-openvswitch-agent:
     container_name: "neutron_openvswitch_agent"
     image: "{{ neutron_openvswitch_agent_image_full }}"
-    enabled: "{{ neutron_plugin_agent == 'openvswitch' }}"
+    enabled: "{{ (neutron_service_limit == 'all' or 'neutron-openvswitch-agent' in _neutron_service_limit) and neutron_plugin_agent == 'openvswitch' }}"
     privileged: True
     environment:
       KOLLA_LEGACY_IPTABLES: "{{ neutron_legacy_iptables | bool | lower }}"
@@ -51,7 +51,7 @@ neutron_services:
     container_name: "neutron_linuxbridge_agent"
     image: "{{  neutron_linuxbridge_agent_image_full }}"
     privileged: True
-    enabled: "{{ neutron_plugin_agent == 'linuxbridge' }}"
+    enabled: "{{ (neutron_service_limit == 'all' or 'neutron-linuxbridge-agent' in _neutron_service_limit) and neutron_plugin_agent == 'linuxbridge' }}"
     environment:
       KOLLA_LEGACY_IPTABLES: "{{ neutron_legacy_iptables | bool | lower }}"
     host_in_groups: >-
@@ -69,7 +69,7 @@ neutron_services:
     container_name: "neutron_dhcp_agent"
     image: "{{ neutron_dhcp_agent_image_full }}"
     privileged: True
-    enabled: "{{ neutron_plugin_agent not in ['ovn', 'vmware_nsxv', 'vmware_nsxv3'] or neutron_ovn_dhcp_agent | bool }}"
+    enabled: "{{ (neutron_service_limit == 'all' or 'neutron-dhcp-agent' in _neutron_service_limit) and neutron_plugin_agent not in ['ovn', 'vmware_nsxv', 'vmware_nsxv3'] or neutron_ovn_dhcp_agent | bool }}"
     group: "neutron-dhcp-agent"
     host_in_groups: "{{ inventory_hostname in groups['neutron-dhcp-agent'] }}"
     volumes: "{{ neutron_dhcp_agent_default_volumes + neutron_dhcp_agent_extra_volumes }}"
@@ -79,7 +79,7 @@ neutron_services:
     container_name: "neutron_l3_agent"
     image: "{{ neutron_l3_agent_image_full }}"
     privileged: True
-    enabled: "{{ neutron_plugin_agent not in ['ovn', 'vmware_nsxv', 'vmware_nsxv3', 'vmware_dvs'] }}"
+    enabled: "{{ (neutron_service_limit == 'all' or 'neutron-l3-agent' in _neutron_service_limit) and neutron_plugin_agent not in ['ovn', 'vmware_nsxv', 'vmware_nsxv3', 'vmware_dvs'] }}"
     environment:
       KOLLA_LEGACY_IPTABLES: "{{ neutron_legacy_iptables | bool | lower }}"
     host_in_groups: >-
@@ -94,7 +94,7 @@ neutron_services:
     container_name: "neutron_sriov_agent"
     image: "{{ neutron_sriov_agent_image_full }}"
     privileged: True
-    enabled: "{{ enable_neutron_sriov | bool and neutron_plugin_agent not in ['vmware_nsxv', 'vmware_nsxv3' ] }}"
+    enabled: "{{ (neutron_service_limit == 'all' or 'neutron-sriov-agent' in _neutron_service_limit) and enable_neutron_sriov | bool and neutron_plugin_agent not in ['vmware_nsxv', 'vmware_nsxv3'] }}"
     host_in_groups: "{{ inventory_hostname in groups['compute'] }}"
     volumes: "{{ neutron_sriov_agent_default_volumes + neutron_sriov_agent_extra_volumes }}"
     dimensions: "{{ neutron_sriov_agent_dimensions }}"
@@ -102,7 +102,7 @@ neutron_services:
   neutron-mlnx-agent:
     container_name: "neutron_mlnx_agent"
     image: "{{ neutron_mlnx_agent_image_full }}"
-    enabled: "{{ enable_neutron_mlnx | bool and neutron_plugin_agent not in ['vmware_nsxv', 'vmware_nsxv3' ] }}"
+    enabled: "{{ (neutron_service_limit == 'all' or 'neutron-mlnx-agent' in _neutron_service_limit) and enable_neutron_mlnx | bool and neutron_plugin_agent not in ['vmware_nsxv', 'vmware_nsxv3'] }}"
     host_in_groups: "{{ inventory_hostname in groups['compute'] }}"
     volumes: "{{ neutron_mlnx_agent_default_volumes + neutron_mlnx_agent_extra_volumes }}"
     dimensions: "{{ neutron_mlnx_agent_dimensions }}"
@@ -110,7 +110,7 @@ neutron_services:
     container_name: "neutron_eswitchd"
     image: "{{ neutron_eswitchd_image_full }}"
     privileged: True
-    enabled: "{{ enable_neutron_mlnx | bool and neutron_plugin_agent not in ['vmware_nsxv', 'vmware_nsxv3' ] }}"
+    enabled: "{{ (neutron_service_limit == 'all' or 'neutron-eswitchd' in _neutron_service_limit) and enable_neutron_mlnx | bool and neutron_plugin_agent not in ['vmware_nsxv', 'vmware_nsxv3'] }}"
     host_in_groups: "{{ inventory_hostname in groups['compute'] }}"
     volumes: "{{ neutron_eswitchd_default_volumes + neutron_eswitchd_extra_volumes }}"
     dimensions: "{{ neutron_eswitchd_dimensions }}"
@@ -118,7 +118,7 @@ neutron_services:
     container_name: "neutron_metadata_agent"
     image: "{{ neutron_metadata_agent_image_full }}"
     privileged: True
-    enabled: "{{ neutron_plugin_agent not in [ 'ovn', 'vmware_nsxv', 'vmware_nsxv3' ] }}"
+    enabled: "{{ (neutron_service_limit == 'all' or 'neutron-metadata-agent' in _neutron_service_limit) and neutron_plugin_agent not in ['ovn', 'vmware_nsxv', 'vmware_nsxv3'] }}"
     host_in_groups: >-
       {{
       inventory_hostname in groups['neutron-metadata-agent']
@@ -131,7 +131,7 @@ neutron_services:
     container_name: "neutron_ovn_metadata_agent"
     image: "{{ neutron_ovn_metadata_agent_image_full }}"
     privileged: True
-    enabled: "{{ neutron_plugin_agent == 'ovn' }}"
+    enabled: "{{ (neutron_service_limit == 'all' or 'neutron-ovn-metadata-agent' in _neutron_service_limit) and neutron_plugin_agent == 'ovn' }}"
     host_in_groups: "{{ inventory_hostname in groups['neutron-ovn-metadata-agent'] }}"
     volumes: "{{ neutron_ovn_metadata_agent_default_volumes + neutron_ovn_metadata_agent_extra_volumes }}"
     dimensions: "{{ neutron_ovn_metadata_agent_dimensions }}"
@@ -140,7 +140,7 @@ neutron_services:
     container_name: "neutron_bgp_dragent"
     image: "{{ neutron_bgp_dragent_image_full }}"
     privileged: True
-    enabled: "{{ enable_neutron_bgp_dragent | bool and neutron_plugin_agent not in ['ovn', 'vmware_nsxv', 'vmware_nsxv3', 'vmware_dvs'] }}"
+    enabled: "{{ (neutron_service_limit == 'all' or 'neutron-bgp-dragent' in _neutron_service_limit) and enable_neutron_bgp_dragent | bool and neutron_plugin_agent not in ['ovn', 'vmware_nsxv', 'vmware_nsxv3', 'vmware_dvs'] }}"
     group: "neutron-bgp-dragent"
     host_in_groups: "{{ inventory_hostname in groups['neutron-bgp-dragent'] }}"
     volumes: "{{ neutron_bgp_dragent_default_volumes + neutron_bgp_dragent_extra_volumes }}"
@@ -149,7 +149,7 @@ neutron_services:
     container_name: "neutron_infoblox_ipam_agent"
     image: "{{ neutron_infoblox_ipam_agent_image_full }}"
     privileged: True
-    enabled: "{{ enable_neutron_infoblox_ipam_agent | bool }}"
+    enabled: "{{ (neutron_service_limit == 'all' or 'neutron-infoblox-ipam-agent' in _neutron_service_limit) and enable_neutron_infoblox_ipam_agent | bool }}"
     group: "neutron-infoblox-ipam-agent"
     host_in_groups: "{{ inventory_hostname in groups['neutron-infoblox-ipam-agent'] }}"
     volumes: "{{ neutron_infoblox_ipam_agent_default_volumes + neutron_infoblox_ipam_agent_extra_volumes }}"
@@ -158,7 +158,7 @@ neutron_services:
     container_name: "neutron_metering_agent"
     image: "{{ neutron_metering_agent_image_full }}"
     privileged: True
-    enabled: "{{ enable_neutron_metering | bool }}"
+    enabled: "{{ (neutron_service_limit == 'all' or 'neutron-metering-agent' in _neutron_service_limit) and enable_neutron_metering | bool }}"
     group: "neutron-metering-agent"
     host_in_groups: "{{ inventory_hostname in groups['neutron-metering-agent'] }}"
     volumes: "{{ neutron_metering_agent_default_volumes + neutron_metering_agent_extra_volumes }}"
@@ -167,7 +167,7 @@ neutron_services:
     container_name: "ironic_neutron_agent"
     image: "{{ ironic_neutron_agent_image_full }}"
     privileged: False
-    enabled: "{{ enable_ironic_neutron_agent | bool }}"
+    enabled: "{{ (neutron_service_limit == 'all' or 'ironic-neutron-agent' in _neutron_service_limit) and enable_ironic_neutron_agent | bool }}"
     group: "ironic-neutron-agent"
     host_in_groups: "{{ inventory_hostname in groups['ironic-neutron-agent'] }}"
     volumes: "{{ ironic_neutron_agent_default_volumes + ironic_neutron_agent_extra_volumes }}"
@@ -177,7 +177,7 @@ neutron_services:
     container_name: neutron_tls_proxy
     group: neutron-server
     host_in_groups: "{{ inventory_hostname in groups['neutron-server'] }}"
-    enabled: "{{ neutron_enable_tls_backend }}"
+    enabled: "{{ (neutron_service_limit == 'all' or 'neutron-tls-proxy' in _neutron_service_limit) and neutron_enable_tls_backend }}"
     image: "{{ neutron_tls_proxy_image_full }}"
     volumes: "{{ neutron_tls_proxy_default_volumes + neutron_tls_proxy_extra_volumes }}"
     dimensions: "{{ neutron_tls_proxy_dimensions }}"
@@ -759,6 +759,7 @@ neutron_git_repository: "{{ kolla_dev_repos_git }}/{{ project_name }}"
 neutron_dev_repos_pull: "{{ kolla_dev_repos_pull }}"
 neutron_dev_mode: "{{ kolla_dev_mode }}"
 neutron_source_version: "{{ kolla_source_version }}"
+neutron_service_limit: "all"
 
 ####################
 # Keystone

--- a/ansible/roles/neutron/vars/main.yml
+++ b/ansible/roles/neutron/vars/main.yml
@@ -1,2 +1,5 @@
 ---
 project_name: "neutron"
+
+# Support ansible style limit strings
+_neutron_service_limit: "{{ neutron_service_limit | split(',') | reject(neutron_service_limit) or neutron_service_limit | split(':') }}"

--- a/releasenotes/notes/adds-neutron-service-limit-b258b80511e0c098.yaml
+++ b/releasenotes/notes/adds-neutron-service-limit-b258b80511e0c098.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Adds the ``neutron_service_limit`` option. This can be used to perform
+    targeted reconfiguration of neutron services. One use case is for two step
+    upgrades where neutron-server is upgraded first, followed by the agents.
+    This can help minimise downtime. Usage: ``-e
+    neutron_service_limit=neutron_server,neutron-dhcp-agent``.


### PR DESCRIPTION
This can be used to perform neutron upgrades in two steps:

- First upgrade neutron server
- Then upgrade the agents

This can help minimise L3 downtime.

Change-Id: Ied685bc7eb71d232b4532e2c598458da7b4c6aa4 (cherry picked from commit 281e61e5fc77d1b547cb019894b5adee81332598)