### PR TITLE
rearrange magnum config.yml

### DIFF
--- a/ansible/roles/magnum/tasks/config.yml
+++ b/ansible/roles/magnum/tasks/config.yml
@@ -35,6 +35,32 @@
   when:
     - kolla_copy_ca_into_containers | bool
 
+- name: Check if management cluster kubeconfig is provided
+  stat:
+    path: "{{ node_custom_config }}/magnum/kubeconfig"
+  register: kubeconfig
+  delegate_to: localhost
+
+- name: Optionally configure magnum for cluster-api driver
+  set_fact:
+    magnum_cluster_api_driver_enabled: true
+  when: kubeconfig.stat.exists
+
+- name: Copying over kubeconfig for management cluster 
+  vars:
+    service: "{{ magnum_services['magnum-conductor'] }}"
+  copy:
+    src: "{{ node_custom_config }}/magnum/kubeconfig"
+    dest: "{{ node_config_directory }}/magnum-conductor/kubeconfig"
+    mode: "0660"
+  become: true
+  when:
+    - inventory_hostname in groups[service.group]
+    - service.enabled | bool
+    - magnum_cluster_api_driver_enabled is defined
+  notify:
+    - Restart magnum-conductor container
+
 - name: Copying over config.json files for services
   template:
     src: "{{ item.key }}.json.j2"
@@ -67,32 +93,6 @@
   with_dict: "{{ magnum_services }}"
   notify:
     - Restart {{ item.key }} container
-    
-- name: Check if management cluster kubeconfig is provided
-  stat:
-    path: "{{ node_custom_config }}/magnum/kubeconfig"
-  register: kubeconfig
-  delegate_to: localhost
-
-- name: Optionally configure magnum for cluster-api driver
-  set_fact:
-    magnum_cluster_api_driver_enabled: true
-  when: kubeconfig.stat.exists
-
-- name: Copying over kubeconfig for management cluster 
-  vars:
-    service: "{{ magnum_services['magnum-conductor'] }}"
-  copy:
-    src: "{{ node_custom_config }}/magnum/kubeconfig"
-    dest: "{{ node_config_directory }}/magnum-conductor/kubeconfig"
-    mode: "0660"
-  become: true
-  when:
-    - inventory_hostname in groups[service.group]
-    - service.enabled | bool
-    - magnum_cluster_api_driver_enabled is defined
-  notify:
-    - Restart magnum-conductor container
 
 - name: Copying over existing policy file
   template:

--- a/ansible/roles/magnum/templates/magnum.conf.j2
+++ b/ansible/roles/magnum/templates/magnum.conf.j2
@@ -61,7 +61,11 @@ ca_file = {{ openstack_cacert }}
 
 [nova_client]
 region_name = {{ openstack_region_name }}
+{% if magnum_cluster_api_driver_enabled is defined %}
+endpoint_type = publicURL
+{% else %}
 endpoint_type = internalURL
+{% endif %}
 ca_file = {{ openstack_cacert }}
 
 [keystone_auth]


### PR DESCRIPTION
the fact determining whether the kubeconfig should be copied into the correct location, as well as the section of magnum.conf telling the capi driver where to find the kubeconfig, was being set after config.json and magnum.conf, resulting in misconfiguration. 

Also magnum.conf is modified to make nova_client use the public url if the capi driver is enabled. This is needed to generate the application credential config injected into the tenant Kubernetes clusters