### PR TITLE
Revert "opensearch: alter path after using rpm/deb packaging"

### DIFF
--- a/ansible/roles/opensearch/templates/opensearch-dashboards.json.j2
+++ b/ansible/roles/opensearch/templates/opensearch-dashboards.json.j2
@@ -1,22 +1,22 @@
 {
-    "command": "/usr/share/opensearch-dashboards/bin/opensearch-dashboards --config /etc/opensearch-dashboards/opensearch_dashboards.yml",
+    "command": "/usr/share/opensearch-dashboards/bin/opensearch-dashboards --config /etc/opensearch/opensearch_dashboards.yml",
     "config_files": [
         {
             "source": "{{ container_config_directory }}/opensearch_dashboards.yml",
-            "dest": "/etc/opensearch-dashboards/opensearch_dashboards.yml",
-            "owner": "opensearch-dashboards",
+            "dest": "/etc/opensearch/opensearch_dashboards.yml",
+            "owner": "opensearch",
             "perm": "0640"
         }
     ],
     "permissions": [
         {
-            "path": "/var/log/kolla/opensearch-dashboards",
-            "owner": "opensearch-dashboards:opensearch-dashboards",
+            "path": "/var/log/kolla/opensearch",
+            "owner": "opensearch:opensearch",
             "recurse": true
         },
         {
-            "path": "/usr/share/opensearch-dashboards/optimize/bundles",
-            "owner": "opensearch-dashboards:opensearch-dashboards",
+            "path": "/usr/share/opensearch/dashboards/optimize/bundles",
+            "owner": "opensearch:opensearch",
             "recurse": true
         },
         {

--- a/ansible/roles/opensearch/templates/opensearch.json.j2
+++ b/ansible/roles/opensearch/templates/opensearch.json.j2
@@ -3,7 +3,7 @@
     "config_files": [
         {
             "source": "{{ container_config_directory }}/opensearch.yml",
-            "dest": "/etc/opensearch/opensearch.yml",
+            "dest": "/usr/share/opensearch/config/opensearch.yml",
             "owner": "opensearch",
             "perm": "0600"
         }

--- a/ansible/roles/opensearch/templates/opensearch_dashboards.yml.j2
+++ b/ansible/roles/opensearch/templates/opensearch_dashboards.yml.j2
@@ -1,5 +1,5 @@
 opensearchDashboards.defaultAppId: "{{ opensearch_dashboards_default_app_id }}"
-logging.dest: /var/log/kolla/opensearch-dashboards/opensearch-dashboards.log
+logging.dest: /var/log/kolla/opensearch/opensearch-dashboards.log
 server.port: {{ opensearch_dashboards_port }}
 server.host: "{{ api_interface_address }}"
 opensearch.hosts: "{{ opensearch_internal_endpoint }}"


### PR DESCRIPTION
This reverts commit 3e6d412a13f2837c566b0daeb1a3d924decc3c72.
    
We need new images for it to work.