### PR TITLE
Support exposing prometheus_server externally

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1170,6 +1170,7 @@ enable_prometheus_etcd_integration: "{{ enable_prometheus | bool and enable_etcd
 enable_prometheus_msteams: "no"
 
 prometheus_alertmanager_user: "admin"
+prometheus_user: "admin"
 prometheus_openstack_exporter_interval: "60s"
 prometheus_openstack_exporter_timeout: "45s"
 prometheus_elasticsearch_exporter_interval: "60s"
@@ -1179,6 +1180,9 @@ prometheus_openstack_exporter_endpoint_type: "internal"
 prometheus_openstack_exporter_compute_api_version: "2.1"
 prometheus_libvirt_exporter_interval: "60s"
 prometheus_msteams_webhook_url:
+
+prometheus_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ prometheus_port }}"
+prometheus_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ prometheus_port }}"
 
 ############
 # Vitrage

--- a/ansible/roles/prometheus/defaults/main.yml
+++ b/ansible/roles/prometheus/defaults/main.yml
@@ -14,6 +14,14 @@ prometheus_services:
         external: false
         port: "{{ prometheus_port }}"
         active_passive: "{{ prometheus_active_passive | bool }}"
+      prometheus_server_external:
+        enabled: "{{ enable_prometheus_server_external | bool }}"
+        mode: "http"
+        external: true
+        port: "{{ prometheus_port }}"
+        auth_user: "{{ prometheus_user }}"
+        auth_pass: "{{ prometheus_password }}"
+        active_passive: "{{ prometheus_active_passive | bool }}"
   prometheus-node-exporter:
     container_name: prometheus_node_exporter
     group: prometheus-node-exporter
@@ -118,6 +126,11 @@ prometheus_services:
     image: "{{ prometheus_msteams_image_full }}"
     volumes: "{{ prometheus_msteams_default_volumes + prometheus_msteams_extra_volumes }}"
     dimensions: "{{ prometheus_msteams_dimensions }}"
+
+####################
+# Server
+####################
+enable_prometheus_server_external: false
 
 ####################
 # Database

--- a/ansible/roles/prometheus/templates/prometheus-server.json.j2
+++ b/ansible/roles/prometheus/templates/prometheus-server.json.j2
@@ -1,5 +1,5 @@
 {
-    "command": "/opt/prometheus/prometheus --config.file /etc/prometheus/prometheus.yml --web.listen-address {{ api_interface_address | put_address_in_context('url') }}:{{ prometheus_port }} --web.external-url={{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ prometheus_port }} --storage.tsdb.path /var/lib/prometheus{% if prometheus_cmdline_extras %} {{ prometheus_cmdline_extras }}{% endif %}",
+    "command": "/opt/prometheus/prometheus --config.file /etc/prometheus/prometheus.yml --web.listen-address {{ api_interface_address | put_address_in_context('url') }}:{{ prometheus_port }} --web.external-url={{ prometheus_public_endpoint if enable_prometheus_server_external else prometheus_internal_endpoint }} --storage.tsdb.path /var/lib/prometheus{% if prometheus_cmdline_extras %} {{ prometheus_cmdline_extras }}{% endif %}",
     "config_files": [
         {
             "source": "{{ container_config_directory }}/prometheus.yml",

--- a/etc/kolla/passwords.yml
+++ b/etc/kolla/passwords.yml
@@ -252,6 +252,7 @@ redis_master_password:
 ####################
 prometheus_mysql_exporter_database_password:
 prometheus_alertmanager_password:
+prometheus_password:
 
 ###############################
 # OpenStack identity federation

--- a/releasenotes/notes/expose-prometheus-on-external-api-78d5fff60f6e75a5.yaml
+++ b/releasenotes/notes/expose-prometheus-on-external-api-78d5fff60f6e75a5.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Adds support for exposing Prometheus server on the external interface. This
+    is disabled by default and can be enabled by setting
+    ``enable_prometheus_server_external`` to ``true``. Basic auth is used to
+    protect the endpoint. The password is under the key ``prometheus_password``
+    in the Kolla passwords file. The username can be configured with
+    ``prometheus_user`` and defaults to ``admin``.


### PR DESCRIPTION
Expose Prometheus endpoint for Azimuth metric collection.

See [openstack capacity](https://github.com/stackhpc/stackhpc-kayobe-config/pull/678)