### PR TITLE
haproxy: support single external frontend

### DIFF
--- a/ansible/filter_plugins/address.py
+++ b/ansible/filter_plugins/address.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from kolla_ansible.kolla_address import kolla_address
+from kolla_ansible.kolla_url import kolla_url
 from kolla_ansible.put_address_in_context import put_address_in_context
 
 
@@ -24,5 +25,6 @@ class FilterModule(object):
     def filters(self):
         return {
             'kolla_address': kolla_address,
+            'kolla_url': kolla_url,
             'put_address_in_context': put_address_in_context,
         }

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -203,7 +203,8 @@ keepalived_virtual_router_id: "51"
 opensearch_datadir_volume: "opensearch"
 elasticsearch_datadir_volume: "elasticsearch"
 
-opensearch_internal_endpoint: "{{ internal_protocol }}://{{ opensearch_address | put_address_in_context('url') }}:{{ opensearch_port }}"
+opensearch_internal_endpoint: "{{ opensearch_address | kolla_url(internal_protocol, opensearch_port) }}"
+opensearch_dashboards_external_fqdn: "{{ kolla_external_fqdn }}"
 opensearch_dashboards_user: "opensearch"
 opensearch_log_index_prefix: "{{ kibana_log_prefix if kibana_log_prefix is defined else 'flog' }}"
 
@@ -291,27 +292,39 @@ neutron_ipam_driver: "internal"
 aodh_internal_fqdn: "{{ kolla_internal_fqdn }}"
 aodh_external_fqdn: "{{ kolla_external_fqdn }}"
 aodh_api_port: "8042"
+aodh_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else aodh_api_port }}"
 aodh_api_listen_port: "{{ aodh_api_port }}"
 
 barbican_internal_fqdn: "{{ kolla_internal_fqdn }}"
 barbican_external_fqdn: "{{ kolla_external_fqdn }}"
 barbican_api_port: "9311"
+barbican_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else barbican_api_port }}"
 barbican_api_listen_port: "{{ barbican_api_port }}"
 
+blazar_internal_fqdn: "{{ kolla_internal_fqdn }}"
+blazar_external_fqdn: "{{ kolla_external_fqdn }}"
 blazar_api_port: "1234"
+blazar_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else blazar_api_port }}"
+blazar_api_listen_port: "{{ blazar_api_port }}"
 
 caso_tcp_output_port: "24224"
 
 ceph_rgw_internal_fqdn: "{{ kolla_internal_fqdn }}"
 ceph_rgw_external_fqdn: "{{ kolla_external_fqdn }}"
 ceph_rgw_port: "6780"
+ceph_rgw_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else ceph_rgw_port }}"
 
 cinder_internal_fqdn: "{{ kolla_internal_fqdn }}"
 cinder_external_fqdn: "{{ kolla_external_fqdn }}"
 cinder_api_port: "8776"
+cinder_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else cinder_api_port }}"
 cinder_api_listen_port: "{{ cinder_api_port }}"
 
+cloudkitty_internal_fqdn: "{{ kolla_internal_fqdn }}"
+cloudkitty_external_fqdn: "{{ kolla_external_fqdn }}"
 cloudkitty_api_port: "8889"
+cloudkitty_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else cloudkitty_api_port }}"
+cloudkitty_api_listen_port: "{{ cloudkitty_api_port }}"
 
 collectd_udp_port: "25826"
 
@@ -321,6 +334,7 @@ designate_internal_fqdn: "{{ kolla_internal_fqdn }}"
 designate_external_fqdn: "{{ kolla_external_fqdn }}"
 designate_api_port: "9001"
 designate_api_listen_port: "{{ designate_api_port }}"
+designate_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else designate_api_port }}"
 designate_bind_port: "53"
 designate_mdns_port: "{{ '53' if designate_backend == 'infoblox' else '5354' }}"
 designate_rndc_port: "953"
@@ -332,12 +346,17 @@ etcd_protocol: "{{ 'https' if etcd_enable_tls | bool else 'http' }}"
 
 fluentd_syslog_port: "5140"
 
+freezer_internal_fqdn: "{{ kolla_internal_fqdn }}"
+freezer_external_fqdn: "{{ kolla_external_fqdn }}"
 freezer_api_port: "9090"
+freezer_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else freezer_api_port }}"
+freezer_api_listen_port: "{{ freezer_api_port }}"
 
 glance_internal_fqdn: "{{ kolla_internal_fqdn }}"
 glance_external_fqdn: "{{ kolla_external_fqdn }}"
 glance_api_port: "9292"
 glance_api_listen_port: "{{ glance_api_port }}"
+glance_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else glance_api_port }}"
 glance_tls_proxy_stats_port: "9293"
 
 gnocchi_internal_fqdn: "{{ kolla_internal_fqdn }}"
@@ -345,7 +364,11 @@ gnocchi_external_fqdn: "{{ kolla_external_fqdn }}"
 gnocchi_api_port: "8041"
 gnocchi_api_listen_port: "{{ gnocchi_api_port }}"
 
+grafana_internal_fqdn: "{{ kolla_internal_fqdn }}"
+grafana_external_fqdn: "{{ kolla_external_fqdn }}"
 grafana_server_port: "3000"
+grafana_server_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else grafana_server_port }}"
+grafana_server_listen_port: "{{ grafana_server_port }}"
 
 haproxy_stats_port: "1984"
 haproxy_monitor_port: "61313"
@@ -354,11 +377,15 @@ heat_internal_fqdn: "{{ kolla_internal_fqdn }}"
 heat_external_fqdn: "{{ kolla_external_fqdn }}"
 heat_api_port: "8004"
 heat_api_listen_port: "{{ heat_api_port }}"
+heat_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else heat_api_port }}"
 heat_cfn_internal_fqdn: "{{ kolla_internal_fqdn }}"
 heat_cfn_external_fqdn: "{{ kolla_external_fqdn }}"
 heat_api_cfn_port: "8000"
 heat_api_cfn_listen_port: "{{ heat_api_cfn_port }}"
+heat_api_cfn_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else heat_api_cfn_port }}"
 
+horizon_internal_fqdn: "{{ kolla_internal_fqdn }}"
+horizon_external_fqdn: "{{ kolla_external_fqdn }}"
 horizon_port: "80"
 horizon_tls_port: "443"
 horizon_listen_port: "{{ horizon_tls_port if horizon_enable_tls_backend | bool else horizon_port }}"
@@ -369,27 +396,39 @@ ironic_internal_fqdn: "{{ kolla_internal_fqdn }}"
 ironic_external_fqdn: "{{ kolla_external_fqdn }}"
 ironic_api_port: "6385"
 ironic_api_listen_port: "{{ ironic_api_port }}"
+ironic_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else ironic_api_port }}"
 ironic_inspector_internal_fqdn: "{{ kolla_internal_fqdn }}"
 ironic_inspector_external_fqdn: "{{ kolla_external_fqdn }}"
 ironic_inspector_port: "5050"
+ironic_inspector_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else ironic_inspector_port }}"
 ironic_inspector_listen_port: "{{ ironic_inspector_port }}"
 ironic_http_port: "8089"
 
 iscsi_port: "3260"
 
-keystone_public_port: "5000"
-keystone_public_listen_port: "{{ keystone_public_port }}"
+keystone_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else keystone_public_listen_port }}"
+keystone_public_listen_port: "5000"
 # NOTE(yoctozepto): Admin port settings are kept only for upgrade compatibility.
 # TODO(yoctozepto): Remove after Zed.
 keystone_admin_port: "35357"
 keystone_admin_listen_port: "{{ keystone_admin_port }}"
+keystone_internal_port: "5000"
+keystone_internal_listen_port: "{{ keystone_internal_port }}"
 keystone_ssh_port: "8023"
 
 kuryr_port: "23750"
 
+magnum_internal_fqdn: "{{ kolla_internal_fqdn }}"
+magnum_external_fqdn: "{{ kolla_external_fqdn }}"
 magnum_api_port: "9511"
+magnum_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else magnum_api_port }}"
+magnum_api_listen_port: "{{ magnum_api_port }}"
 
+manila_internal_fqdn: "{{ kolla_internal_fqdn }}"
+manila_external_fqdn: "{{ kolla_external_fqdn }}"
 manila_api_port: "8786"
+manila_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else manila_api_port }}"
+manila_api_listen_port: "{{ manila_api_port }}"
 
 mariadb_port: "{{ database_port }}"
 mariadb_wsrep_port: "4567"
@@ -408,11 +447,20 @@ mariadb_shard_root_user_prefix: "root_shard_"
 mariadb_shard_backup_user_prefix: "backup_shard_"
 mariadb_shards_info: "{{ groups['mariadb'] | database_shards_info() }}"
 
+masakari_internal_fqdn: "{{ kolla_internal_fqdn }}"
+masakari_external_fqdn: "{{ kolla_external_fqdn }}"
 masakari_api_port: "15868"
+masakari_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else masakari_api_port }}"
+masakari_api_listen_port: "{{ masakari_api_port }}"
+masakari_coordination_backend: "{{ 'redis' if enable_redis | bool else 'etcd' if enable_etcd | bool else '' }}"
 
 memcached_port: "11211"
 
+mistral_internal_fqdn: "{{ kolla_internal_fqdn }}"
+mistral_external_fqdn: "{{ kolla_external_fqdn }}"
 mistral_api_port: "8989"
+mistral_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else mistral_api_port }}"
+mistral_api_listen_port: "{{ mistral_api_port }}"
 
 # TODO(dougszu): Remove in A cycle
 monasca_api_port: "8070"
@@ -420,35 +468,47 @@ monasca_log_api_port: "{{ monasca_api_port }}"
 monasca_agent_forwarder_port: "17123"
 monasca_agent_statsd_port: "8125"
 
+murano_internal_fqdn: "{{ kolla_internal_fqdn }}"
+murano_external_fqdn: "{{ kolla_external_fqdn }}"
 murano_api_port: "8082"
+murano_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else murano_api_port }}"
+murano_api_listen_port: "{{ murano_api_listen_port }}"
 
 neutron_internal_fqdn: "{{ kolla_internal_fqdn }}"
 neutron_external_fqdn: "{{ kolla_external_fqdn }}"
 neutron_server_port: "9696"
 neutron_server_listen_port: "{{ neutron_server_port }}"
+neutron_server_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else neutron_server_port }}"
 neutron_tls_proxy_stats_port: "9697"
 
 nova_internal_fqdn: "{{ kolla_internal_fqdn }}"
 nova_external_fqdn: "{{ kolla_external_fqdn }}"
 nova_api_port: "8774"
 nova_api_listen_port: "{{ nova_api_port }}"
+nova_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else nova_api_port }}"
+nova_metadata_internal_fqdn: "{{ kolla_internal_fqdn }}"
+nova_metadata_external_fqdn: "{{ kolla_external_fqdn }}"
 nova_metadata_port: "8775"
 nova_metadata_listen_port: "{{ nova_metadata_port }}"
 nova_novncproxy_fqdn: "{{ kolla_external_fqdn }}"
 nova_novncproxy_port: "6080"
 nova_novncproxy_listen_port: "{{ nova_novncproxy_port }}"
+nova_novncproxy_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else nova_novncproxy_port }}"
 nova_spicehtml5proxy_fqdn: "{{ kolla_external_fqdn }}"
 nova_spicehtml5proxy_port: "6082"
 nova_spicehtml5proxy_listen_port: "{{ nova_spicehtml5proxy_port }}"
+nova_spicehtml5proxy_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else nova_spicehtml5proxy_port }}"
 nova_serialproxy_fqdn: "{{ kolla_external_fqdn }}"
 nova_serialproxy_port: "6083"
 nova_serialproxy_listen_port: "{{ nova_serialproxy_port }}"
+nova_serialproxy_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else nova_serialproxy_port }}"
 nova_serialproxy_protocol: "{{ 'wss' if kolla_enable_tls_external | bool else 'ws' }}"
 
 octavia_internal_fqdn: "{{ kolla_internal_fqdn }}"
 octavia_external_fqdn: "{{ kolla_external_fqdn }}"
 octavia_api_port: "9876"
 octavia_api_listen_port: "{{ octavia_api_port }}"
+octavia_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else octavia_api_port }}"
 octavia_health_manager_port: "5555"
 
 # NOTE: If an external ElasticSearch cluster port is specified,
@@ -456,7 +516,8 @@ octavia_health_manager_port: "5555"
 # endpoints. This is for backwards compatibility.
 opensearch_port: "{{ elasticsearch_port | default('9200') }}"
 opensearch_dashboards_port: "5601"
-opensearch_dashboards_port_external: "{{ opensearch_dashboards_port }}"
+opensearch_dashboards_port_external: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else  opensearch_dashboards_port }}"
+opensearch_dashboards_listen_port: "{{ opensearch_dashboards_port }}"
 
 ovn_nb_db_port: "6641"
 ovn_sb_db_port: "6642"
@@ -476,6 +537,7 @@ placement_external_fqdn: "{{ kolla_external_fqdn }}"
 # Default Placement API port of 8778 already in use
 placement_api_port: "8780"
 placement_api_listen_port: "{{ placement_api_port }}"
+placement_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else placement_api_port }}"
 
 prometheus_port: "9091"
 prometheus_node_exporter_port: "9100"
@@ -490,8 +552,12 @@ prometheus_libvirt_exporter_port: "9177"
 prometheus_etcd_integration_port: "{{ etcd_client_port }}"
 
 # Prometheus alertmanager ports
+prometheus_alertmanager_internal_fqdn: "{{ kolla_internal_fqdn }}"
+prometheus_alertmanager_external_fqdn: "{{ kolla_external_fqdn }}"
 prometheus_alertmanager_port: "9093"
 prometheus_alertmanager_cluster_port: "9094"
+prometheus_alertmanager_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else prometheus_alertmanager_port }}"
+prometheus_alertmanager_listen_port: "{{ prometheus_alertmanager_port }}"
 
 # Prometheus MSTeams port
 prometheus_msteams_port: "9095"
@@ -517,18 +583,31 @@ rabbitmq_prometheus_port: "15692"
 redis_port: "6379"
 redis_sentinel_port: "26379"
 
+sahara_internal_fqdn: "{{ kolla_internal_fqdn }}"
+sahara_external_fqdn: "{{ kolla_external_fqdn }}"
 sahara_api_port: "8386"
+sahara_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else sahara_api_port }}"
+sahara_api_listen_port: "{{ sahara_api_port }}"
 
 senlin_internal_fqdn: "{{ kolla_internal_fqdn }}"
 senlin_external_fqdn: "{{ kolla_external_fqdn }}"
 senlin_api_port: "8778"
 senlin_api_listen_port: "{{ senlin_api_port }}"
+senlin_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else senlin_api_port }}"
 
 skydive_analyzer_port: "8085"
 skydive_agents_port: "8090"
 
+solum_application_deployment_internal_fqdn: "{{ kolla_internal_fqdn }}"
+solum_application_deployment_external_fqdn: "{{ kolla_external_fqdn }}"
 solum_application_deployment_port: "9777"
+solum_application_deployment_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else solum_application_deployment_port }}"
+solum_application_deployment_listen_port: "{{ solum_application_deployment_port }}"
+solum_image_builder_internal_fqdn: "{{ kolla_internal_fqdn }}"
+solum_image_builder_external_fqdn: "{{ kolla_external_fqdn }}"
 solum_image_builder_port: "9778"
+solum_image_builder_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else solum_image_builder_port }}"
+solum_image_builder_listen_port: "{{ solum_image_builder_port }}"
 
 storm_nimbus_thrift_port: 6627
 storm_supervisor_thrift_port: 6628
@@ -550,20 +629,46 @@ swift_rsync_port: "10873"
 
 syslog_udp_port: "{{ fluentd_syslog_port }}"
 
+tacker_internal_fqdn: "{{ kolla_internal_fqdn }}"
+tacker_external_fqdn: "{{ kolla_external_fqdn }}"
 tacker_server_port: "9890"
+tacker_server_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else tacker_server_port }}"
+tacker_server_listen_port: "{{ tacker_server_port }}"
 
+trove_internal_fqdn: "{{ kolla_internal_fqdn }}"
+trove_external_fqdn: "{{ kolla_external_fqdn }}"
 trove_api_port: "8779"
+trove_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else trove_api_port }}"
+trove_api_listen_port: "{{ trove_api_port }}"
 
+venus_internal_fqdn: "{{ kolla_internal_fqdn }}"
+venus_external_fqdn: "{{ kolla_external_fqdn }}"
 venus_api_port: "10010"
+venus_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else venus_api_port }}"
+venus_api_listen_port: "{{ venus_api_port }}"
 
+watcher_internal_fqdn: "{{ kolla_internal_fqdn }}"
+watcher_external_fqdn: "{{ kolla_external_fqdn }}"
 watcher_api_port: "9322"
+watcher_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else watcher_api_port }}"
+watcher_api_listen_port: "{{ watcher_api_port }}"
 
 zun_api_port: "9517"
+zun_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else zun_api_port }}"
+zun_api_listen_port: "{{ zun_api_port }}"
+zun_wsproxy_internal_fqdn: "{{ kolla_internal_fqdn }}"
+zun_wsproxy_external_fqdn: "{{ kolla_external_fqdn }}"
 zun_wsproxy_port: "6784"
 zun_wsproxy_protocol: "{{ 'wss' if kolla_enable_tls_external | bool else 'ws' }}"
 zun_cni_daemon_port: "9036"
+zun_internal_fqdn: "{{ kolla_internal_fqdn }}"
+zun_external_fqdn: "{{ kolla_external_fqdn }}"
 
+vitrage_internal_fqdn: "{{ kolla_internal_fqdn }}"
+vitrage_external_fqdn: "{{ kolla_external_fqdn }}"
 vitrage_api_port: "8999"
+vitrage_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else vitrage_api_port }}"
+vitrage_api_listen_port: "{{ vitrage_api_port }}"
 
 public_protocol: "{{ 'https' if kolla_enable_tls_external | bool else 'http' }}"
 internal_protocol: "{{ 'https' if kolla_enable_tls_internal | bool else 'http' }}"
@@ -820,6 +925,7 @@ osprofiler_backend_connection_string: "{{ redis_connection_string if osprofiler_
 rabbitmq_user: "openstack"
 rabbitmq_monitoring_user: ""
 outward_rabbitmq_user: "openstack"
+outward_rabbitmq_external_fqdn: "{{ kolla_external_fqdn }}"
 # Whether to enable TLS encryption for RabbitMQ client-server communication.
 rabbitmq_enable_tls: "no"
 # CA certificate bundle in RabbitMQ container.
@@ -839,6 +945,8 @@ kolla_admin_openrc_cacert: ""
 kolla_copy_ca_into_containers: "no"
 haproxy_backend_cacert: "{{ 'ca-certificates.crt' if kolla_base_distro in ['debian', 'ubuntu'] else 'ca-bundle.trust.crt' }}"
 haproxy_backend_cacert_dir: "/etc/ssl/certs"
+haproxy_single_external_frontend: false
+haproxy_single_external_frontend_public_port: "{{ '443' if kolla_enable_tls_external | bool else '80' }}"
 
 ##################
 # Backend options
@@ -866,9 +974,9 @@ keystone_internal_fqdn: "{{ kolla_internal_fqdn }}"
 keystone_external_fqdn: "{{ kolla_external_fqdn }}"
 
 # TODO(yoctozepto): Remove after Zed. Kept for compatibility only.
-keystone_admin_url: "{{ keystone_internal_url }}"
-keystone_internal_url: "{{ internal_protocol }}://{{ keystone_internal_fqdn | put_address_in_context('url') }}:{{ keystone_public_port }}"
-keystone_public_url: "{{ public_protocol }}://{{ keystone_external_fqdn | put_address_in_context('url') }}:{{ keystone_public_port }}"
+keystone_admin_url: "{{ keystone_internal_fqdn | kolla_url(admin_protocol, keystone_admin_port) }}"
+keystone_internal_url: "{{ keystone_internal_fqdn | kolla_url(internal_protocol, keystone_internal_port) }}"
+keystone_public_url: "{{ keystone_external_fqdn | kolla_url(public_protocol, keystone_public_port) }}"
 
 keystone_admin_user: "admin"
 keystone_admin_project: "admin"
@@ -916,8 +1024,8 @@ glance_api_hosts: "{{ [groups['glance-api'] | first] if glance_backend_file | bo
 # NOTE(mnasiadka): For use in common role
 glance_enable_tls_backend: "{{ kolla_enable_tls_backend }}"
 
-glance_internal_endpoint: "{{ internal_protocol }}://{{ glance_internal_fqdn | put_address_in_context('url') }}:{{ glance_api_port }}"
-glance_public_endpoint: "{{ public_protocol }}://{{ glance_external_fqdn | put_address_in_context('url') }}:{{ glance_api_port }}"
+glance_internal_endpoint: "{{ glance_internal_fqdn | kolla_url(internal_protocol, glance_api_port) }}"
+glance_public_endpoint: "{{ glance_external_fqdn | kolla_url(public_protocol, glance_api_public_port) }}"
 
 #######################
 # Barbican options
@@ -926,8 +1034,8 @@ glance_public_endpoint: "{{ public_protocol }}://{{ glance_external_fqdn | put_a
 barbican_crypto_plugin: "simple_crypto"
 barbican_library_path: "/usr/lib/libCryptoki2_64.so"
 
-barbican_internal_endpoint: "{{ internal_protocol }}://{{ barbican_internal_fqdn | put_address_in_context('url') }}:{{ barbican_api_port }}"
-barbican_public_endpoint: "{{ public_protocol }}://{{ barbican_external_fqdn | put_address_in_context('url') }}:{{ barbican_api_port }}"
+barbican_internal_endpoint: "{{ barbican_internal_fqdn | kolla_url(internal_protocol, barbican_api_port) }}"
+barbican_public_endpoint: "{{ barbican_external_fqdn | kolla_url(public_protocol, barbican_api_public_port) }}"
 
 #################
 # Gnocchi options
@@ -977,8 +1085,8 @@ designate_backend_external_bind9_nameservers: ""
 # Valid options are [ '', redis ]
 designate_coordination_backend: "{{ 'redis' if enable_redis | bool else '' }}"
 
-designate_internal_endpoint: "{{ internal_protocol }}://{{ designate_internal_fqdn | put_address_in_context('url') }}:{{ designate_api_port }}"
-designate_public_endpoint: "{{ public_protocol }}://{{ designate_external_fqdn | put_address_in_context('url') }}:{{ designate_api_port }}"
+designate_internal_endpoint: "{{ designate_internal_fqdn | kolla_url(internal_protocol, designate_api_port) }}"
+designate_public_endpoint: "{{ designate_external_fqdn | kolla_url(public_protocol, designate_api_public_port) }}"
 
 designate_enable_notifications_sink: "{{ enable_designate | bool }}"
 designate_notifications_topic_name: "notifications_designate"
@@ -1007,8 +1115,8 @@ neutron_legacy_iptables: "no"
 # Enable distributed floating ip for OVN deployments
 neutron_ovn_distributed_fip: "no"
 
-neutron_internal_endpoint: "{{ internal_protocol }}://{{ neutron_internal_fqdn | put_address_in_context('url') }}:{{ neutron_server_port }}"
-neutron_public_endpoint: "{{ public_protocol }}://{{ neutron_external_fqdn | put_address_in_context('url') }}:{{ neutron_server_port }}"
+neutron_internal_endpoint: "{{ neutron_internal_fqdn | kolla_url(internal_protocol, neutron_server_port) }}"
+neutron_public_endpoint: "{{ neutron_external_fqdn | kolla_url(public_protocol, neutron_server_public_port) }}"
 
 # SRIOV physnet:interface mappings when SRIOV is enabled
 # "sriovnet1" and tunnel_interface used here as placeholders
@@ -1060,8 +1168,8 @@ enable_nova_horizon_policy_file: "{{ enable_nova }}"
 
 horizon_enable_tls_backend: "{{ kolla_enable_tls_backend }}"
 
-horizon_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ horizon_tls_port if kolla_enable_tls_internal | bool else horizon_port }}"
-horizon_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ horizon_tls_port if kolla_enable_tls_external | bool else horizon_port }}"
+horizon_internal_endpoint: "{{ kolla_internal_fqdn | kolla_url(internal_protocol, horizon_tls_port if kolla_enable_tls_internal | bool else horizon_port) }}"
+horizon_public_endpoint: "{{ kolla_external_fqdn | kolla_url(public_protocol, horizon_tls_port if kolla_enable_tls_external | bool else horizon_port) }}"
 
 ###################
 # External Ceph options
@@ -1157,7 +1265,7 @@ enable_vitrage_prometheus_datasource: "{{ enable_prometheus | bool }}"
 influxdb_address: "{{ kolla_internal_fqdn }}"
 influxdb_datadir_volume: "influxdb"
 
-influxdb_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ influxdb_http_port }}"
+influxdb_internal_endpoint: "{{ kolla_internal_fqdn | kolla_url(internal_protocol, influxdb_http_port) }}"
 
 #########################
 # Internal Image options
@@ -1187,20 +1295,20 @@ kolla_base_distro_version: "{{ kolla_base_distro_version_default_map[kolla_base_
 # telemetry data.
 telegraf_enable_docker_input: "no"
 
-vitrage_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ vitrage_api_port }}"
-vitrage_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ vitrage_api_port }}"
+vitrage_internal_endpoint: "{{ kolla_internal_fqdn | kolla_url(internal_protocol, vitrage_api_port) }}"
+vitrage_public_endpoint: "{{ kolla_external_fqdn | kolla_url(public_protocol, vitrage_api_public_port) }}"
 
 ####################
 # Grafana
 ####################
-grafana_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ grafana_server_port }}"
-grafana_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ grafana_server_port }}"
+grafana_internal_endpoint: "{{ kolla_internal_fqdn | kolla_url(internal_protocol, grafana_server_port) }}"
+grafana_public_endpoint: "{{ kolla_external_fqdn | kolla_url(public_protocol, grafana_server_public_port) }}"
 
 #############
 # Ironic
 #############
-ironic_internal_endpoint: "{{ internal_protocol }}://{{ ironic_internal_fqdn | put_address_in_context('url') }}:{{ ironic_api_port }}"
-ironic_public_endpoint: "{{ public_protocol }}://{{ ironic_external_fqdn | put_address_in_context('url') }}:{{ ironic_api_port }}"
+ironic_internal_endpoint: "{{ ironic_internal_fqdn | kolla_url(internal_protocol, ironic_api_port) }}"
+ironic_public_endpoint: "{{ ironic_external_fqdn | kolla_url(public_protocol, ironic_api_public_port) }}"
 
 # Valid options are [ '', redis, etcd ]
 ironic_coordination_backend: "{{ 'redis' if enable_redis | bool else 'etcd' if enable_etcd | bool else '' }}"
@@ -1208,10 +1316,10 @@ ironic_coordination_backend: "{{ 'redis' if enable_redis | bool else 'etcd' if e
 ########
 # Swift
 ########
-swift_internal_base_endpoint: "{{ internal_protocol }}://{{ swift_internal_fqdn | put_address_in_context('url') }}:{{ swift_proxy_server_port }}"
+swift_internal_base_endpoint: "{{ swift_internal_fqdn | kolla_url(internal_protocol, swift_proxy_server_port) }}"
 
 swift_internal_endpoint: "{{ swift_internal_base_endpoint }}/v1/AUTH_%(tenant_id)s"
-swift_public_endpoint: "{{ public_protocol }}://{{ swift_external_fqdn | put_address_in_context('url') }}:{{ swift_proxy_server_port }}/v1/AUTH_%(tenant_id)s"
+swift_public_endpoint: "{{ swift_external_fqdn | kolla_url(public_protocol, swift_proxy_server_port, '/v1/AUTH_%(tenant_id)s') }}"
 
 ##########
 # Octavia
@@ -1229,8 +1337,8 @@ octavia_auto_configure: "{{ 'amphora' in octavia_provider_drivers }}"
 #   on the Octavia woker nodes on the same provider network.
 octavia_network_type: "provider"
 
-octavia_internal_endpoint: "{{ internal_protocol }}://{{ octavia_internal_fqdn | put_address_in_context('url') }}:{{ octavia_api_port }}"
-octavia_public_endpoint: "{{ public_protocol }}://{{ octavia_external_fqdn | put_address_in_context('url') }}:{{ octavia_api_port }}"
+octavia_internal_endpoint: "{{ octavia_internal_fqdn | kolla_url(internal_protocol, octavia_api_port) }}"
+octavia_public_endpoint: "{{ octavia_external_fqdn | kolla_url(public_protocol, octavia_api_public_port) }}"
 
 ###################################
 # Identity federation configuration

--- a/ansible/roles/aodh/defaults/main.yml
+++ b/ansible/roles/aodh/defaults/main.yml
@@ -19,7 +19,8 @@ aodh_services:
         enabled: "{{ enable_aodh }}"
         mode: "http"
         external: true
-        port: "{{ aodh_api_port }}"
+        external_fqdn: "{{ aodh_external_fqdn }}"
+        port: "{{ aodh_api_public_port }}"
         listen_port: "{{ aodh_api_listen_port }}"
   aodh-evaluator:
     container_name: aodh_evaluator
@@ -201,8 +202,8 @@ aodh_notifier_extra_volumes: "{{ aodh_extra_volumes }}"
 ####################
 # OpenStack
 ####################
-aodh_internal_endpoint: "{{ internal_protocol }}://{{ aodh_internal_fqdn | put_address_in_context('url') }}:{{ aodh_api_port }}"
-aodh_public_endpoint: "{{ public_protocol }}://{{ aodh_external_fqdn | put_address_in_context('url') }}:{{ aodh_api_port }}"
+aodh_internal_endpoint: "{{ aodh_internal_fqdn | kolla_url(internal_protocol, aodh_api_port) }}"
+aodh_public_endpoint: "{{ aodh_external_fqdn | kolla_url(public_protocol, aodh_api_public_port) }}"
 
 aodh_logging_debug: "{{ openstack_logging_debug }}"
 

--- a/ansible/roles/barbican/defaults/main.yml
+++ b/ansible/roles/barbican/defaults/main.yml
@@ -20,7 +20,8 @@ barbican_services:
         enabled: "{{ enable_barbican }}"
         mode: "http"
         external: true
-        port: "{{ barbican_api_port }}"
+        external_fqdn: "{{ barbican_external_fqdn }}"
+        port: "{{ barbican_api_public_port }}"
         listen_port: "{{ barbican_api_listen_port }}"
         tls_backend: "{{ barbican_enable_tls_backend }}"
   barbican-keystone-listener:

--- a/ansible/roles/blazar/defaults/main.yml
+++ b/ansible/roles/blazar/defaults/main.yml
@@ -14,11 +14,14 @@ blazar_services:
         mode: "http"
         external: false
         port: "{{ blazar_api_port }}"
+        listen_port: "{{ blazar_api_listen_port }}"
       blazar_api_external:
         enabled: "{{ enable_blazar }}"
         mode: "http"
         external: true
-        port: "{{ blazar_api_port }}"
+        external_fqdn: "{{ blazar_external_fqdn }}"
+        port: "{{ blazar_api_public_port }}"
+        listen_port: "{{ blazar_api_listen_port }}"
   blazar-manager:
     container_name: blazar_manager
     group: blazar-manager
@@ -119,8 +122,8 @@ blazar_manager_extra_volumes: "{{ blazar_extra_volumes }}"
 ####################
 # OpenStack
 ####################
-blazar_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ blazar_api_port }}/v1"
-blazar_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ blazar_api_port }}/v1"
+blazar_internal_endpoint: "{{ blazar_internal_fqdn | kolla_url(internal_protocol, blazar_api_port, '/v1') }}"
+blazar_public_endpoint: "{{ blazar_external_fqdn | kolla_url(public_protocol, blazar_api_public_port, '/v1') }}"
 
 blazar_logging_debug: "{{ openstack_logging_debug }}"
 

--- a/ansible/roles/ceph-rgw/defaults/main.yml
+++ b/ansible/roles/ceph-rgw/defaults/main.yml
@@ -16,7 +16,8 @@ ceph_rgw_services:
         enabled: "{{ enable_ceph_rgw_loadbalancer | bool }}"
         mode: "http"
         external: true
-        port: "{{ ceph_rgw_port }}"
+        external_fqdn: "{{ ceph_rgw_external_fqdn }}"
+        port: "{{ ceph_rgw_public_port }}"
         custom_member_list: "{{ ceph_rgw_haproxy_members }}"
 
 ####################
@@ -59,8 +60,8 @@ ceph_rgw_swift_account_in_url: false
 
 ceph_rgw_endpoint_path: "{{ '/' if ceph_rgw_swift_compatibility | bool else '/swift/' }}v1{% if ceph_rgw_swift_account_in_url | bool %}/AUTH_%(project_id)s{% endif %}"
 
-ceph_rgw_internal_endpoint: "{{ internal_protocol }}://{{ ceph_rgw_internal_fqdn | put_address_in_context('url') }}:{{ ceph_rgw_port }}{{ ceph_rgw_endpoint_path }}"
-ceph_rgw_public_endpoint: "{{ public_protocol }}://{{ ceph_rgw_external_fqdn | put_address_in_context('url') }}:{{ ceph_rgw_port }}{{ ceph_rgw_endpoint_path }}"
+ceph_rgw_internal_endpoint: "{{ ceph_rgw_internal_fqdn | kolla_url(internal_protocol, ceph_rgw_port, ceph_rgw_endpoint_path) }}"
+ceph_rgw_public_endpoint: "{{ ceph_rgw_external_fqdn | kolla_url(public_protocol, ceph_rgw_public_port, ceph_rgw_endpoint_path) }}"
 
 ceph_rgw_keystone_user: "ceph_rgw"
 

--- a/ansible/roles/cinder/defaults/main.yml
+++ b/ansible/roles/cinder/defaults/main.yml
@@ -20,7 +20,8 @@ cinder_services:
         enabled: "{{ enable_cinder }}"
         mode: "http"
         external: true
-        port: "{{ cinder_api_port }}"
+        external_fqdn: "{{ cinder_external_fqdn }}"
+        port: "{{ cinder_api_public_port }}"
         listen_port: "{{ cinder_api_listen_port }}"
         tls_backend: "{{ cinder_enable_tls_backend }}"
   cinder-scheduler:
@@ -202,8 +203,8 @@ cinder_enable_conversion_tmpfs: false
 ####################
 # OpenStack
 ####################
-cinder_internal_base_endpoint: "{{ internal_protocol }}://{{ cinder_internal_fqdn | put_address_in_context('url') }}:{{ cinder_api_port }}"
-cinder_public_base_endpoint: "{{ public_protocol }}://{{ cinder_external_fqdn | put_address_in_context('url') }}:{{ cinder_api_port }}"
+cinder_internal_base_endpoint: "{{ cinder_internal_fqdn | kolla_url(internal_protocol, cinder_api_port) }}"
+cinder_public_base_endpoint: "{{ cinder_external_fqdn | kolla_url(public_protocol, cinder_api_public_port) }}"
 
 cinder_v3_internal_endpoint: "{{ cinder_internal_base_endpoint }}/v3/%(tenant_id)s"
 cinder_v3_public_endpoint: "{{ cinder_public_base_endpoint }}/v3/%(tenant_id)s"

--- a/ansible/roles/cloudkitty/defaults/main.yml
+++ b/ansible/roles/cloudkitty/defaults/main.yml
@@ -14,11 +14,14 @@ cloudkitty_services:
         mode: "http"
         external: false
         port: "{{ cloudkitty_api_port }}"
+        listen_port: "{{ cloudkitty_api_listen_port }}"
       cloudkitty_api_external:
         enabled: "{{ enable_cloudkitty }}"
         mode: "http"
         external: true
-        port: "{{ cloudkitty_api_port }}"
+        external_fqdn: "{{ cloudkitty_external_fqdn }}"
+        port: "{{ cloudkitty_api_public_port }}"
+        listen_port: "{{ cloudkitty_api_listen_port }}"
   cloudkitty-processor:
     container_name: "cloudkitty_processor"
     group: "cloudkitty-processor"
@@ -112,8 +115,8 @@ cloudkitty_api_extra_volumes: "{{ cloudkitty_extra_volumes }}"
 ####################
 # OpenStack
 ####################
-cloudkitty_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ cloudkitty_api_port }}"
-cloudkitty_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ cloudkitty_api_port }}"
+cloudkitty_internal_endpoint: "{{ cloudkitty_internal_fqdn | kolla_url(internal_protocol, cloudkitty_api_port) }}"
+cloudkitty_public_endpoint: "{{ cloudkitty_external_fqdn | kolla_url(public_protocol, cloudkitty_api_public_port) }}"
 
 cloudkitty_logging_debug: "{{ openstack_logging_debug }}"
 

--- a/ansible/roles/cyborg/defaults/main.yml
+++ b/ansible/roles/cyborg/defaults/main.yml
@@ -134,8 +134,8 @@ cyborg_conductor_extra_volumes: "{{ cyborg_extra_volumes }}"
 ####################
 # OpenStack
 ####################
-cyborg_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ cyborg_api_port }}/v2"
-cyborg_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ cyborg_api_port }}/v2"
+cyborg_internal_endpoint: "{{ cyborg_internal_fqdn | kolla_url(internal_protocol, cyborg_api_port) }}"
+cyborg_public_endpoint: "{{ cyborg_external_fqdn | kolla_url(public_protocol, cyborg_api_port) }}"
 
 cyborg_logging_debug: "{{ openstack_logging_debug }}"
 

--- a/ansible/roles/designate/defaults/main.yml
+++ b/ansible/roles/designate/defaults/main.yml
@@ -19,7 +19,8 @@ designate_services:
         enabled: "{{ enable_designate }}"
         mode: "http"
         external: true
-        port: "{{ designate_api_port }}"
+        external_fqdn: "{{ designate_external_fqdn }}"
+        port: "{{ designate_api_public_port }}"
         listen_port: "{{ designate_api_listen_port }}"
   designate-backend-bind9:
     container_name: designate_backend_bind9

--- a/ansible/roles/freezer/defaults/main.yml
+++ b/ansible/roles/freezer/defaults/main.yml
@@ -13,11 +13,14 @@ freezer_services:
         mode: "http"
         external: false
         port: "{{ freezer_api_port }}"
+        listen_port: "{{ freezer_api_listen_port }}"
       freezer_api_external:
         enabled: "{{ enable_freezer }}"
         mode: "http"
         external: true
-        port: "{{ freezer_api_port }}"
+        external_fqdn: "{{ freezer_external_fqdn }}"
+        port: "{{ freezer_api_public_port }}"
+        listen_port: "{{ freezer_api_listen_port }}"
   freezer-scheduler:
     container_name: freezer_scheduler
     group: freezer-scheduler
@@ -90,8 +93,8 @@ freezer_scheduler_extra_volumes: "{{ freezer_extra_volumes }}"
 ####################
 # OpenStack
 ####################
-freezer_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ freezer_api_port }}"
-freezer_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ freezer_api_port }}"
+freezer_internal_endpoint: "{{ freezer_internal_fqdn | kolla_url(internal_protocol, freezer_api_port) }}"
+freezer_public_endpoint: "{{ freezer_external_fqdn | kolla_url(public_protocol, freezer_api_public_port) }}"
 
 freezer_logging_debug: "{{ openstack_logging_debug }}"
 

--- a/ansible/roles/glance/defaults/main.yml
+++ b/ansible/roles/glance/defaults/main.yml
@@ -26,7 +26,8 @@ glance_services:
         enabled: "{{ enable_glance | bool and not glance_enable_tls_backend | bool }}"
         mode: "http"
         external: true
-        port: "{{ glance_api_port }}"
+        external_fqdn: "{{ glance_external_fqdn }}"
+        port: "{{ glance_api_public_port }}"
         frontend_http_extra:
           - "timeout client {{ haproxy_glance_api_client_timeout }}"
         backend_http_extra:
@@ -57,7 +58,8 @@ glance_services:
         enabled: "{{ enable_glance | bool and glance_enable_tls_backend | bool }}"
         mode: "http"
         external: true
-        port: "{{ glance_api_port }}"
+        external_fqdn: "{{ glance_external_fqdn }}"
+        port: "{{ glance_api_public_port }}"
         frontend_http_extra:
           - "timeout client {{ haproxy_glance_api_client_timeout }}"
         backend_http_extra:

--- a/ansible/roles/gnocchi/defaults/main.yml
+++ b/ansible/roles/gnocchi/defaults/main.yml
@@ -13,12 +13,15 @@ gnocchi_services:
         enabled: "{{ enable_gnocchi }}"
         mode: "http"
         external: false
-        port: "{{ gnocchi_api_listen_port }}"
+        port: "{{ gnocchi_api_port }}"
+        listen_port: "{{ gnocchi_api_listen_port }}"
       gnocchi_api_external:
         enabled: "{{ enable_gnocchi }}"
         mode: "http"
         external: true
-        port: "{{ gnocchi_api_listen_port }}"
+        external_fqdn: "{{ gnocchi_external_fqdn }}"
+        port: "{{ gnocchi_api_public_port }}"
+        listen_port: "{{ gnocchi_api_listen_port }}"
   gnocchi-metricd:
     container_name: gnocchi_metricd
     group: gnocchi-metricd
@@ -154,8 +157,8 @@ gnocchi_statsd_extra_volumes: "{{ gnocchi_extra_volumes }}"
 ####################
 # OpenStack
 ####################
-gnocchi_internal_endpoint: "{{ internal_protocol }}://{{ gnocchi_internal_fqdn | put_address_in_context('url') }}:{{ gnocchi_api_port }}"
-gnocchi_public_endpoint: "{{ public_protocol }}://{{ gnocchi_external_fqdn | put_address_in_context('url') }}:{{ gnocchi_api_port }}"
+gnocchi_internal_endpoint: "{{ gnocchi_internal_fqdn | kolla_url(internal_protocol, gnocchi_api_port) }}"
+gnocchi_public_endpoint: "{{ gnocchi_external_fqdn | kolla_url(public_protocol, gnocchi_api_public_port) }}"
 
 gnocchi_logging_debug: "{{ openstack_logging_debug }}"
 

--- a/ansible/roles/grafana/defaults/main.yml
+++ b/ansible/roles/grafana/defaults/main.yml
@@ -13,11 +13,14 @@ grafana_services:
         mode: "http"
         external: false
         port: "{{ grafana_server_port }}"
+        listen_port: "{{ grafana_server_listen_port }}"
       grafana_server_external:
         enabled: "{{ enable_grafana_external | bool }}"
         mode: "http"
         external: true
-        port: "{{ grafana_server_port }}"
+        external_fqdn: "{{ grafana_external_fqdn }}"
+        port: "{{ grafana_server_public_port }}"
+        listen_port: "{{ grafana_server_listen_port }}"
 
 ####################
 # Database

--- a/ansible/roles/haproxy-config/tasks/main.yml
+++ b/ansible/roles/haproxy-config/tasks/main.yml
@@ -22,6 +22,36 @@
   notify:
     - Restart haproxy container
 
+- name: "Add configuration for {{ project_name }} when using single external frontend"
+  vars:
+    service: "{{ item.value }}"
+  blockinfile:
+    create: yes
+    path: "{{ node_config_directory }}/haproxy/external-frontend-map"
+    insertafter: EOF
+    marker: "# {mark} {{ item.key }}"
+    mode: "0660"
+    block: |
+      {%- set haproxy = service.haproxy | default({}) %}
+      {%- for haproxy_name, haproxy_service in haproxy.items() %}
+      {% set external = haproxy_service.external | default(false) | bool %}
+      {% set enabled = haproxy_service.enabled | default(false) | bool %}
+      {% set with_frontend = haproxy_service.with_frontend | default(true) | bool %}
+      {% set mode = haproxy_service.mode | default('http') %}
+      {%- if external and with_frontend and enabled and mode == 'http' %}
+      {{ haproxy_service.external_fqdn }} {{ haproxy_name }}_back
+      {% endif -%}
+      {%- endfor -%}
+  become: true
+  with_dict: "{{ project_services }}"
+  when:
+    - haproxy_single_external_frontend | bool
+    - service.enabled | bool
+    - service.haproxy is defined
+    - enable_haproxy | bool
+  notify:
+    - Restart haproxy container
+
 - name: "Configuring firewall for {{ project_name }}"
   firewalld:
     offline: "yes"

--- a/ansible/roles/haproxy-config/templates/haproxy_single_service_split.cfg.j2
+++ b/ansible/roles/haproxy-config/templates/haproxy_single_service_split.cfg.j2
@@ -140,8 +140,10 @@ backend {{ service_name }}_back
 {{ userlist_macro(haproxy_name, auth_user, auth_pass) }}
         {% endif %}
         {% if with_frontend %}
+            {% if not (external|bool and haproxy_single_external_frontend|bool and mode == 'http') %}
 {{ frontend_macro(haproxy_name, haproxy_service.port, mode, external,
                   frontend_http_extra, frontend_tcp_extra) }}
+            {% endif %}
         {% endif %}
         {# Redirect (to https) is a special case, as it does not include a backend #}
         {% if with_backend and mode != 'redirect' %}

--- a/ansible/roles/heat/defaults/main.yml
+++ b/ansible/roles/heat/defaults/main.yml
@@ -20,7 +20,8 @@ heat_services:
         enabled: "{{ enable_heat }}"
         mode: "http"
         external: true
-        port: "{{ heat_api_port }}"
+        external_fqdn: "{{ heat_external_fqdn }}"
+        port: "{{ heat_api_public_port }}"
         listen_port: "{{ heat_api_listen_port }}"
         tls_backend: "{{ heat_enable_tls_backend }}"
   heat-api-cfn:
@@ -43,7 +44,8 @@ heat_services:
         enabled: "{{ enable_heat }}"
         mode: "http"
         external: true
-        port: "{{ heat_api_cfn_port }}"
+        external_fqdn: "{{ heat_cfn_external_fqdn }}"
+        port: "{{ heat_api_cfn_public_port }}"
         listen_port: "{{ heat_api_cfn_listen_port }}"
         tls_backend: "{{ heat_enable_tls_backend }}"
   heat-engine:
@@ -163,12 +165,12 @@ heat_engine_extra_volumes: "{{ heat_extra_volumes }}"
 ####################
 # OpenStack
 ####################
-heat_internal_endpoint: "{{ internal_protocol }}://{{ heat_internal_fqdn | put_address_in_context('url') }}:{{ heat_api_port }}/v1/%(tenant_id)s"
-heat_public_endpoint: "{{ public_protocol }}://{{ heat_external_fqdn | put_address_in_context('url') }}:{{ heat_api_port }}/v1/%(tenant_id)s"
+heat_internal_endpoint: "{{ heat_internal_fqdn | kolla_url(internal_protocol, heat_api_port, '/v1/%(tenant_id)s') }}"
+heat_public_endpoint: "{{ heat_external_fqdn | kolla_url(public_protocol, heat_api_public_port, '/v1/%(tenant_id)s') }}"
 
-heat_cfn_public_base_endpoint: "{{ public_protocol }}://{{ heat_cfn_external_fqdn | put_address_in_context('url') }}:{{ heat_api_cfn_port }}"
+heat_cfn_public_base_endpoint: "{{ heat_cfn_external_fqdn | kolla_url(public_protocol, heat_api_cfn_public_port) }}"
 
-heat_cfn_internal_endpoint: "{{ internal_protocol }}://{{ heat_cfn_internal_fqdn | put_address_in_context('url') }}:{{ heat_api_cfn_port }}/v1"
+heat_cfn_internal_endpoint: "{{ heat_cfn_internal_fqdn | kolla_url(internal_protocol, heat_api_cfn_port, '/v1') }}"
 heat_cfn_public_endpoint: "{{ heat_cfn_public_base_endpoint }}/v1"
 
 heat_logging_debug: "{{ openstack_logging_debug }}"

--- a/ansible/roles/horizon/defaults/main.yml
+++ b/ansible/roles/horizon/defaults/main.yml
@@ -53,6 +53,7 @@ horizon_services:
         enabled: "{{ enable_horizon }}"
         mode: "http"
         external: true
+        external_fqdn: "{{ horizon_external_fqdn }}"
         port: "{% if kolla_enable_tls_external | bool %}{{ horizon_tls_port }}{% else %}{{ horizon_port }}{% endif %}"
         listen_port: "{{ horizon_listen_port }}"
         frontend_http_extra:
@@ -64,6 +65,7 @@ horizon_services:
         enabled: "{{ enable_horizon | bool and kolla_enable_tls_external | bool }}"
         mode: "redirect"
         external: true
+        external_fqdn: "{{ horizon_external_fqdn }}"
         port: "{{ horizon_port }}"
         listen_port: "{{ horizon_listen_port }}"
       acme_client:

--- a/ansible/roles/ironic/defaults/main.yml
+++ b/ansible/roles/ironic/defaults/main.yml
@@ -20,7 +20,8 @@ ironic_services:
         enabled: "{{ enable_ironic }}"
         mode: "http"
         external: true
-        port: "{{ ironic_api_port }}"
+        external_fqdn: "{{ ironic_external_fqdn }}"
+        port: "{{ ironic_api_public_port }}"
         listen_port: "{{ ironic_api_listen_port }}"
         tls_backend: "{{ ironic_enable_tls_backend }}"
   ironic-conductor:
@@ -52,7 +53,8 @@ ironic_services:
         enabled: "{{ enable_ironic }}"
         mode: "http"
         external: true
-        port: "{{ ironic_inspector_port }}"
+        external_fqdn: "{{ ironic_inspector_external_fqdn }}"
+        port: "{{ ironic_inspector_public_port }}"
         listen_port: "{{ ironic_inspector_listen_port }}"
   ironic-tftp:
     container_name: ironic_tftp
@@ -253,8 +255,8 @@ ironic_dnsmasq_extra_volumes: "{{ ironic_extra_volumes }}"
 ####################
 ironic_inspector_keystone_user: "ironic-inspector"
 
-ironic_inspector_internal_endpoint: "{{ internal_protocol }}://{{ ironic_inspector_internal_fqdn | put_address_in_context('url') }}:{{ ironic_inspector_port }}"
-ironic_inspector_public_endpoint: "{{ public_protocol }}://{{ ironic_inspector_external_fqdn | put_address_in_context('url') }}:{{ ironic_inspector_port }}"
+ironic_inspector_internal_endpoint: "{{ ironic_inspector_internal_fqdn | kolla_url(internal_protocol, ironic_inspector_port) }}"
+ironic_inspector_public_endpoint: "{{ ironic_inspector_external_fqdn | kolla_url(public_protocol, ironic_inspector_public_port) }}"
 
 ironic_logging_debug: "{{ openstack_logging_debug }}"
 

--- a/ansible/roles/keystone/defaults/main.yml
+++ b/ansible/roles/keystone/defaults/main.yml
@@ -14,13 +14,14 @@ keystone_services:
         mode: "http"
         external: false
         tls_backend: "{{ keystone_enable_tls_backend }}"
-        port: "{{ keystone_public_port }}"
-        listen_port: "{{ keystone_public_listen_port }}"
+        port: "{{ keystone_internal_port }}"
+        listen_port: "{{ keystone_internal_listen_port }}"
         backend_http_extra: "{{ ['balance source'] if enable_keystone_federation | bool else [] }}"
       keystone_external:
         enabled: "{{ enable_keystone }}"
         mode: "http"
         external: true
+        external_fqdn: "{{ keystone_external_fqdn }}"
         tls_backend: "{{ keystone_enable_tls_backend }}"
         port: "{{ keystone_public_port }}"
         listen_port: "{{ keystone_public_listen_port }}"

--- a/ansible/roles/loadbalancer/defaults/main.yml
+++ b/ansible/roles/loadbalancer/defaults/main.yml
@@ -150,3 +150,15 @@ kolla_externally_managed_cert: False
 # Allow to disable keepalived tracking script (e.g. for single node environments
 # where this proves problematic in some cases)
 keepalived_track_script_enabled: True
+
+# Default backend for single external frontend (for missing mappings)
+haproxy_external_single_frontend_default_backend: "horizon_external_back"
+
+haproxy_external_single_frontend_public_port: "443"
+
+haproxy_external_single_frontend_options:
+  - option httplog
+  - option forwardfor
+  - "timeout client {{ haproxy_glance_api_client_timeout }}"
+
+haproxy_glance_api_client_timeout: "6h"

--- a/ansible/roles/loadbalancer/tasks/config.yml
+++ b/ansible/roles/loadbalancer/tasks/config.yml
@@ -156,6 +156,21 @@
   notify:
     - Restart proxysql container
 
+- name: Copying over haproxy single external frontend config
+  vars:
+    service: "{{ loadbalancer_services['haproxy'] }}"
+  template:
+    src: "haproxy/haproxy_external_frontend.cfg.j2"
+    dest: "{{ node_config_directory }}/haproxy/services.d/external-frontend.cfg"
+    mode: "0660"
+  become: true
+  when:
+    - inventory_hostname in groups[service.group]
+    - service.enabled | bool
+    - haproxy_single_external_frontend | bool
+  notify:
+    - Restart haproxy container
+
 - name: Copying over custom haproxy services configuration
   vars:
     service: "{{ loadbalancer_services['haproxy'] }}"

--- a/ansible/roles/loadbalancer/templates/haproxy/haproxy.json.j2
+++ b/ansible/roles/loadbalancer/templates/haproxy/haproxy.json.j2
@@ -20,6 +20,13 @@
             "perm": "0700"
         },
         {
+            "source": "{{ container_config_directory }}/external-frontend-map",
+            "dest": "/etc/haproxy/external-frontend-map",
+            "owner": "root",
+            "perm": "0600",
+            "optional": {{ (not haproxy_single_external_frontend | bool) | string | lower }}
+        },
+        {
             "source": "{{ container_config_directory }}/haproxy.pem",
             "dest": "/etc/haproxy/haproxy.pem",
             "owner": "root",

--- a/ansible/roles/loadbalancer/templates/haproxy/haproxy_external_frontend.cfg.j2
+++ b/ansible/roles/loadbalancer/templates/haproxy/haproxy_external_frontend.cfg.j2
@@ -1,0 +1,11 @@
+{%- set external_tls_bind_info = 'ssl crt /etc/haproxy/haproxy.pem' if kolla_enable_tls_external|bool else '' %}
+
+frontend external_frontend
+    mode http
+    http-request del-header X-Forwarded-Proto
+{% for http_option in haproxy_external_single_frontend_options %}
+    {{ http_option }}
+{% endfor %}
+    http-request set-header X-Forwarded-Proto https if { ssl_fc }
+    bind {{ kolla_external_vip_address }}:{{ haproxy_external_single_frontend_public_port }} {{ external_tls_bind_info }}
+    use_backend %[req.hdr(host),lower,map_dom(/etc/haproxy/external-frontend-map,{{ haproxy_external_single_frontend_default_backend }})]

--- a/ansible/roles/magnum/defaults/main.yml
+++ b/ansible/roles/magnum/defaults/main.yml
@@ -16,11 +16,14 @@ magnum_services:
         mode: "http"
         external: false
         port: "{{ magnum_api_port }}"
+        listen_port: "{{ magnum_api_listen_port }}"
       magnum_api_external:
         enabled: "{{ enable_magnum }}"
         mode: "http"
         external: true
-        port: "{{ magnum_api_port }}"
+        external_fqdn: "{{ magnum_external_fqdn }}"
+        port: "{{ magnum_api_public_port }}"
+        listen_port: "{{ magnum_api_listen_port }}"
   magnum-conductor:
     container_name: magnum_conductor
     group: magnum-conductor
@@ -127,8 +130,8 @@ magnum_conductor_container_proxy: "{{ container_proxy }}"
 ####################
 # OpenStack
 ####################
-magnum_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ magnum_api_port }}/v1"
-magnum_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ magnum_api_port }}/v1"
+magnum_internal_endpoint: "{{ magnum_internal_fqdn | kolla_url(internal_protocol, magnum_api_port, '/v1') }}"
+magnum_public_endpoint: "{{ magnum_external_fqdn | kolla_url(public_protocol,  magnum_api_public_port, '/v1') }}"
 
 magnum_logging_debug: "{{ openstack_logging_debug }}"
 

--- a/ansible/roles/manila/defaults/main.yml
+++ b/ansible/roles/manila/defaults/main.yml
@@ -14,11 +14,14 @@ manila_services:
         mode: "http"
         external: false
         port: "{{ manila_api_port }}"
+        listen_port: "{{ manila_api_listen_port }}"
       manila_api_external:
         enabled: "{{ enable_manila }}"
         mode: "http"
         external: true
-        port: "{{ manila_api_port }}"
+        external_fqdn: "{{ manila_external_fqdn }}"
+        port: "{{ manila_api_public_port }}"
+        listen_port: "{{ manila_api_listen_port }}"
   manila-scheduler:
     container_name: "manila_scheduler"
     group: "manila-scheduler"
@@ -184,8 +187,8 @@ manila_data_extra_volumes: "{{ manila_extra_volumes }}"
 #####################
 ## OpenStack
 #####################
-manila_internal_base_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ manila_api_port }}"
-manila_public_base_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ manila_api_port }}"
+manila_internal_base_endpoint: "{{ manila_internal_fqdn | kolla_url(internal_protocol, manila_api_port) }}"
+manila_public_base_endpoint: "{{ manila_external_fqdn | kolla_url(public_protocol, manila_api_public_port) }}"
 
 manila_internal_endpoint: "{{ manila_internal_base_endpoint }}/v1/%(tenant_id)s"
 manila_public_endpoint: "{{ manila_public_base_endpoint }}/v1/%(tenant_id)s"

--- a/ansible/roles/masakari/defaults/main.yml
+++ b/ansible/roles/masakari/defaults/main.yml
@@ -13,11 +13,14 @@ masakari_services:
         mode: "http"
         external: false
         port: "{{ masakari_api_port }}"
+        listen_port: "{{ masakari_api_listen_port }}"
       masakari_api_external:
         enabled: "{{ enable_masakari }}"
         mode: "http"
         external: true
-        port: "{{ masakari_api_port }}"
+        external_fqdn: "{{ masakari_external_fqdn }}"
+        port: "{{ masakari_api_public_port }}"
+        listen_port: "{{ masakari_api_listen_port }}"
   masakari-engine:
     container_name: masakari_engine
     group: masakari-engine
@@ -124,8 +127,8 @@ masakari_hostmonitor_default_volumes:
 ####################
 # OpenStack
 ####################
-masakari_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ masakari_api_port }}"
-masakari_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ masakari_api_port }}"
+masakari_internal_endpoint: "{{ masakari_internal_fqdn | kolla_url(internal_protocol, masakari_api_port) }}"
+masakari_public_endpoint: "{{ masakari_external_fqdn | kolla_url(public_protocol, masakari_api_public_port) }}"
 
 masakari_logging_debug: "{{ openstack_logging_debug }}"
 

--- a/ansible/roles/mistral/defaults/main.yml
+++ b/ansible/roles/mistral/defaults/main.yml
@@ -14,11 +14,14 @@ mistral_services:
         mode: "http"
         external: false
         port: "{{ mistral_api_port }}"
+        listen_port: "{{ mistral_api_listen_port }}"
       mistral_api_external:
         enabled: "{{ enable_mistral }}"
         mode: "http"
         external: true
-        port: "{{ mistral_api_port }}"
+        external_fqdn: "{{ mistral_external_fqdn }}"
+        port: "{{ mistral_api_public_port }}"
+        listen_port: "{{ mistral_api_listen_port }}"
   mistral-engine:
     container_name: mistral_engine
     group: mistral-engine
@@ -178,10 +181,10 @@ mistral_api_extra_volumes: "{{ mistral_extra_volumes }}"
 ####################
 # OpenStack
 ####################
-mistral_internal_base_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ mistral_api_port }}"
+mistral_internal_base_endpoint: "{{ mistral_internal_fqdn | kolla_url(internal_protocol, mistral_api_port) }}"
 
 mistral_internal_endpoint: "{{ mistral_internal_base_endpoint }}/v2"
-mistral_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ mistral_api_port }}/v2"
+mistral_public_endpoint: "{{ mistral_external_fqdn | kolla_url(public_protocol, mistral_api_public_port, '/v2') }}"
 
 mistral_logging_debug: "{{ openstack_logging_debug }}"
 

--- a/ansible/roles/monasca/defaults/main.yml
+++ b/ansible/roles/monasca/defaults/main.yml
@@ -13,11 +13,14 @@ monasca_services:
         mode: "http"
         external: false
         port: "{{ monasca_api_port }}"
+        listen_port: "{{ monasca_api_listen_port }}"
       monasca_api_external:
         enabled: false
         mode: "http"
         external: true
-        port: "{{ monasca_api_port }}"
+        external_fqdn: "{{ monasca_external_fqdn }}"
+        port: "{{ monasca_api_public_port }}"
+        listen_port: "{{ monasca_api_listen_port }}"
   monasca-log-persister:
     container_name: monasca_log_persister
     group: monasca-log-persister

--- a/ansible/roles/murano/defaults/main.yml
+++ b/ansible/roles/murano/defaults/main.yml
@@ -13,11 +13,14 @@ murano_services:
         mode: "http"
         external: false
         port: "{{ murano_api_port }}"
+        listen_port: "{{ murano_api_listen_port }}"
       murano_api_external:
         enabled: "{{ enable_murano }}"
         mode: "http"
         external: true
-        port: "{{ murano_api_port }}"
+        external_fqdn: "{{ murano_external_fqdn }}"
+        port: "{{ murano_api_public_port }}"
+        listen_port: "{{ murano_api_listen_port }}"
   murano-engine:
     container_name: murano_engine
     group: murano-engine
@@ -84,8 +87,8 @@ murano_engine_extra_volumes: "{{ murano_extra_volumes }}"
 ####################
 # OpenStack
 ####################
-murano_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ murano_api_port }}"
-murano_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ murano_api_port }}"
+murano_internal_endpoint: "{{ murano_internal_fqdn | kolla_url(internal_protocol, murano_api_port) }}"
+murano_public_endpoint: "{{ murano_external_fqdn | kolla_url(public_protocol, murano_api_public_port) }}"
 
 murano_logging_debug: "{{ openstack_logging_debug }}"
 

--- a/ansible/roles/murano/templates/murano.conf.j2
+++ b/ansible/roles/murano/templates/murano.conf.j2
@@ -81,7 +81,7 @@ policy_file = {{ murano_policy_file }}
 
 {% if service_name == 'murano-engine' %}
 [rabbitmq]
-host = {{ kolla_external_fqdn }}
+host = {{ rabbitmq_external_fqdn }}
 port = {{ outward_rabbitmq_port }}
 login = {{ murano_agent_rabbitmq_user }}
 password = {{ murano_agent_rabbitmq_password }}

--- a/ansible/roles/neutron/defaults/main.yml
+++ b/ansible/roles/neutron/defaults/main.yml
@@ -20,7 +20,8 @@ neutron_services:
         enabled: "{{ enable_neutron | bool and not neutron_enable_tls_backend | bool }}"
         mode: "http"
         external: true
-        port: "{{ neutron_server_port }}"
+        external_fqdn: "{{ neutron_external_fqdn }}"
+        port: "{{ neutron_server_public_port }}"
         listen_port: "{{ neutron_server_listen_port }}"
   neutron-openvswitch-agent:
     container_name: "neutron_openvswitch_agent"
@@ -194,6 +195,7 @@ neutron_services:
         enabled: "{{ enable_neutron | bool and neutron_enable_tls_backend | bool }}"
         mode: "http"
         external: true
+        external_fqdn: "{{ neutron_external_fqdn }}"
         port: "{{ neutron_server_port }}"
         listen_port: "{{ neutron_server_listen_port }}"
         tls_backend: "yes"

--- a/ansible/roles/nova-cell/tasks/loadbalancer.yml
+++ b/ansible/roles/nova-cell/tasks/loadbalancer.yml
@@ -48,7 +48,8 @@
             enabled: "{{ hostvars[groups[cell_proxy_group][0]]['nova_console'] == 'novnc' }}"
             mode: "http"
             external: true
-            port: "{{ hostvars[groups[cell_proxy_group][0]]['nova_novncproxy_port'] }}"
+            external_fqdn: "{{ hostvars[groups[cell_proxy_group][0]]['nova_novncproxy_fqdn'] }}"
+            port: "{{ hostvars[groups[cell_proxy_group][0]]['nova_novncproxy_public_port'] }}"
             listen_port: "{{ hostvars[groups[cell_proxy_group][0]]['nova_novncproxy_listen_port'] }}"
             backend_http_extra:
               - "timeout tunnel 1h"
@@ -84,7 +85,8 @@
             enabled: "{{ hostvars[groups[cell_proxy_group][0]]['nova_console'] == 'spice' }}"
             mode: "http"
             external: true
-            port: "{{ hostvars[groups[cell_proxy_group][0]]['nova_spicehtml5proxy_port'] }}"
+            external_fqdn: "{{ hostvars[groups[cell_proxy_group][0]]['nova_spicehtml5proxy_fqdn'] }}"
+            port: "{{ hostvars[groups[cell_proxy_group][0]]['nova_spicehtml5proxy_public_port'] }}"
             listen_port: "{{ hostvars[groups[cell_proxy_group][0]]['nova_spicehtml5proxy_listen_port'] }}"
             backend_http_extra:
               - "timeout tunnel {{ haproxy_nova_spicehtml5_proxy_tunnel_timeout }}"
@@ -120,7 +122,8 @@
             enabled: "{{ hostvars[groups[cell_proxy_group][0]]['enable_nova_serialconsole_proxy'] | bool }}"
             mode: "http"
             external: true
-            port: "{{ hostvars[groups[cell_proxy_group][0]]['nova_serialproxy_port'] }}"
+            external_fqdn: "{{ hostvars[groups[cell_proxy_group][0]]['nova_serialproxy_fqdn'] }}"
+            port: "{{ hostvars[groups[cell_proxy_group][0]]['nova_serialproxy_public_port'] }}"
             listen_port: "{{ hostvars[groups[cell_proxy_group][0]]['nova_serialproxy_listen_port'] }}"
             backend_http_extra:
               - "timeout tunnel {{ haproxy_nova_serialconsole_proxy_tunnel_timeout }}"

--- a/ansible/roles/nova-cell/templates/nova.conf.j2
+++ b/ansible/roles/nova-cell/templates/nova.conf.j2
@@ -49,7 +49,7 @@ novncproxy_port = {{ nova_novncproxy_listen_port }}
 server_listen = {{ api_interface_address }}
 server_proxyclient_address = {{ api_interface_address }}
 {% if inventory_hostname in groups[nova_cell_compute_group] %}
-novncproxy_base_url = {{ public_protocol }}://{{ nova_novncproxy_fqdn | put_address_in_context('url') }}:{{ nova_novncproxy_port }}/vnc_lite.html
+novncproxy_base_url = {{ nova_novncproxy_fqdn | kolla_url(public_protocol,  nova_novncproxy_public_port, '/vnc_lite.html') }}
 {% endif %}
 {% endif %}
 {% elif nova_console == 'spice' %}
@@ -61,7 +61,7 @@ enabled = true
 server_listen = {{ api_interface_address }}
 server_proxyclient_address = {{ api_interface_address }}
 {% if inventory_hostname in groups[nova_cell_compute_group] %}
-html5proxy_base_url = {{ public_protocol }}://{{ nova_spicehtml5proxy_fqdn | put_address_in_context('url') }}:{{ nova_spicehtml5proxy_port }}/spice_auto.html
+html5proxy_base_url = {{ nova_spicehtml5proxy_fqdn | kolla_url(public_protocol, nova_spicehtml5proxy_public_port, '/spice_auto.html') }}
 {% endif %}
 html5proxy_host = {{ api_interface_address }}
 html5proxy_port = {{ nova_spicehtml5proxy_listen_port }}
@@ -74,7 +74,7 @@ enabled = false
 {% if enable_nova_serialconsole_proxy | bool %}
 [serial_console]
 enabled = true
-base_url = {{ nova_serialproxy_protocol }}://{{ nova_serialproxy_fqdn | put_address_in_context('url') }}:{{ nova_serialproxy_port }}/
+base_url = {{ nova_serialproxy_fqdn | kolla_url(nova_serialproxy_protocol, nova_serialproxy_public_port) }}/
 serialproxy_host = {{ api_interface_address }}
 serialproxy_port = {{ nova_serialproxy_listen_port }}
 proxyclient_address = {{ api_interface_address }}

--- a/ansible/roles/nova/defaults/main.yml
+++ b/ansible/roles/nova/defaults/main.yml
@@ -21,7 +21,8 @@ nova_services:
         enabled: "{{ enable_nova }}"
         mode: "http"
         external: true
-        port: "{{ nova_api_port }}"
+        external_fqdn: "{{ nova_external_fqdn }}"
+        port: "{{ nova_api_public_port }}"
         listen_port: "{{ nova_api_listen_port }}"
         tls_backend: "{{ nova_enable_tls_backend }}"
       nova_metadata:
@@ -35,6 +36,7 @@ nova_services:
         enabled: "{{ nova_enable_external_metadata }}"
         mode: "http"
         external: true
+        external_fqdn: "{{ nova_metadata_external_fqdn }}"
         port: "{{ nova_metadata_port }}"
         listen_port: "{{ nova_metadata_listen_port }}"
         tls_backend: "{{ nova_enable_tls_backend }}"
@@ -189,8 +191,8 @@ nova_api_bootstrap_extra_volumes: "{{ nova_extra_volumes }}"
 ####################
 # OpenStack
 ####################
-nova_internal_base_endpoint: "{{ internal_protocol }}://{{ nova_internal_fqdn | put_address_in_context('url') }}:{{ nova_api_port }}"
-nova_public_base_endpoint: "{{ public_protocol }}://{{ nova_external_fqdn | put_address_in_context('url') }}:{{ nova_api_port }}"
+nova_internal_base_endpoint: "{{ nova_internal_fqdn | kolla_url(internal_protocol, nova_api_port) }}"
+nova_public_base_endpoint: "{{ nova_external_fqdn | kolla_url(public_protocol,  nova_api_public_port) }}"
 
 nova_legacy_internal_endpoint: "{{ nova_internal_base_endpoint }}/v2/%(tenant_id)s"
 nova_legacy_public_endpoint: "{{ nova_public_base_endpoint }}/v2/%(tenant_id)s"

--- a/ansible/roles/octavia/defaults/main.yml
+++ b/ansible/roles/octavia/defaults/main.yml
@@ -20,7 +20,8 @@ octavia_services:
         enabled: "{{ enable_octavia }}"
         mode: "http"
         external: true
-        port: "{{ octavia_api_port }}"
+        external_fqdn: "{{ octavia_external_fqdn }}"
+        port: "{{ octavia_api_public_port }}"
         listen_port: "{{ octavia_api_listen_port }}"
         tls_backend: "{{ octavia_enable_tls_backend }}"
   octavia-driver-agent:

--- a/ansible/roles/opensearch/defaults/main.yml
+++ b/ansible/roles/opensearch/defaults/main.yml
@@ -40,7 +40,9 @@ opensearch_services:
         enabled: "{{ enable_opensearch_dashboards_external | bool }}"
         mode: "http"
         external: true
+        external_fqdn: "{{ opensearch_dashboards_external_fqdn }}"
         port: "{{ opensearch_dashboards_port_external }}"
+        listen_port: "{{ opensearch_dashboards_listen_port }}"
         auth_user: "{{ opensearch_dashboards_user }}"
         auth_pass: "{{ opensearch_dashboards_password }}"
 

--- a/ansible/roles/placement/defaults/main.yml
+++ b/ansible/roles/placement/defaults/main.yml
@@ -20,7 +20,8 @@ placement_services:
         enabled: "{{ enable_placement }}"
         mode: "http"
         external: true
-        port: "{{ placement_api_port }}"
+        external_fqdn: "{{ placement_external_fqdn }}"
+        port: "{{ placement_api_public_port }}"
         listen_port: "{{ placement_api_listen_port }}"
         tls_backend: "{{ placement_enable_tls_backend }}"
 
@@ -81,8 +82,8 @@ placement_api_extra_volumes: "{{ default_extra_volumes }}"
 ####################
 # OpenStack
 ####################
-placement_internal_endpoint: "{{ internal_protocol }}://{{ placement_internal_fqdn | put_address_in_context('url') }}:{{ placement_api_port }}"
-placement_public_endpoint: "{{ public_protocol }}://{{ placement_external_fqdn | put_address_in_context('url') }}:{{ placement_api_port }}"
+placement_internal_endpoint: "{{ placement_internal_fqdn | kolla_url(internal_protocol, placement_api_port) }}"
+placement_public_endpoint: "{{ placement_external_fqdn | kolla_url(public_protocol, placement_api_public_port) }}"
 
 placement_logging_debug: "{{ openstack_logging_debug }}"
 

--- a/ansible/roles/prometheus/defaults/main.yml
+++ b/ansible/roles/prometheus/defaults/main.yml
@@ -70,7 +70,9 @@ prometheus_services:
         enabled: "{{ enable_prometheus_alertmanager_external | bool }}"
         mode: "http"
         external: true
-        port: "{{ prometheus_alertmanager_port }}"
+        external_fqdn: "{{ prometheus_alertmanager_external_fqdn }}"
+        port: "{{ prometheus_alertmanager_public_port }}"
+        listen_port: "{{ prometheus_alertmanager_listen_port }}"
         auth_user: "{{ prometheus_alertmanager_user }}"
         auth_pass: "{{ prometheus_alertmanager_password }}"
         active_passive: "{{ prometheus_alertmanager_active_passive | bool }}"
@@ -149,7 +151,7 @@ prometheus_alertmanager_active_passive: true
 # 'service_name:blackbox_exporter_module:endpoint' for example:
 #
 # prometheus_blackbox_exporter_targets:
-#   - 'glance:os_endpoint:{{ external_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ glance_api_port}}'
+#   - 'glance:os_endpoint:{{ external_protocol }}://{{ glance_external_fqdn | put_address_in_context('url') }}:{{ glance_api_port}}'
 #
 # For a list of modules see the alertmanager config.
 prometheus_blackbox_exporter_endpoints: []

--- a/ansible/roles/rabbitmq/defaults/main.yml
+++ b/ansible/roles/rabbitmq/defaults/main.yml
@@ -32,6 +32,7 @@ rabbitmq_services:
         enabled: "{{ enable_outward_rabbitmq }}"
         mode: "tcp"
         external: true
+        external_fqdn: "{{ outward_rabbitmq_external_fqdn }}"
         port: "{{ outward_rabbitmq_port }}"
         host_group: "outward-rabbitmq"
         frontend_tcp_extra:

--- a/ansible/roles/sahara/defaults/main.yml
+++ b/ansible/roles/sahara/defaults/main.yml
@@ -14,11 +14,14 @@ sahara_services:
         mode: "http"
         external: false
         port: "{{ sahara_api_port }}"
+        listen_port: "{{ sahara_api_listen_port }}"
       sahara_api_external:
         enabled: "{{ enable_sahara }}"
         mode: "http"
         external: true
-        port: "{{ sahara_api_port }}"
+        external_fqdn: "{{ sahara_external_fqdn }}"
+        port: "{{ sahara_api_public_port }}"
+        listen_port: "{{ sahara_api_listen_port }}"
   sahara-engine:
     container_name: sahara_engine
     group: sahara-engine
@@ -116,8 +119,8 @@ sahara_engine_extra_volumes: "{{ sahara_extra_volumes }}"
 ####################
 # OpenStack
 ####################
-sahara_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ sahara_api_port }}"
-sahara_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ sahara_api_port }}"
+sahara_internal_endpoint: "{{ sahara_internal_fqdn | kolla_url(internal_protocol, sahara_api_port) }}"
+sahara_public_endpoint: "{{ sahara_external_fqdn | kolla_url(public_protocol, sahara_api_public_port) }}"
 
 sahara_logging_debug: "{{ openstack_logging_debug }}"
 

--- a/ansible/roles/senlin/defaults/main.yml
+++ b/ansible/roles/senlin/defaults/main.yml
@@ -19,7 +19,8 @@ senlin_services:
         enabled: "{{ enable_senlin }}"
         mode: "http"
         external: true
-        port: "{{ senlin_api_port }}"
+        external_fqdn: "{{ senlin_external_fqdn }}"
+        port: "{{ senlin_api_public_port }}"
         listen_port: "{{ senlin_api_listen_port }}"
   senlin-conductor:
     container_name: senlin_conductor
@@ -179,8 +180,8 @@ senlin_health_manager_extra_volumes: "{{ senlin_extra_volumes }}"
 ####################
 # OpenStack
 ####################
-senlin_internal_endpoint: "{{ internal_protocol }}://{{ senlin_internal_fqdn | put_address_in_context('url') }}:{{ senlin_api_port }}"
-senlin_public_endpoint: "{{ public_protocol }}://{{ senlin_external_fqdn | put_address_in_context('url') }}:{{ senlin_api_port }}"
+senlin_internal_endpoint: "{{ senlin_internal_fqdn | kolla_url(internal_protocol, senlin_api_port) }}"
+senlin_public_endpoint: "{{ senlin_external_fqdn | kolla_url(public_protocol, senlin_api_public_port) }}"
 
 senlin_logging_debug: "{{ openstack_logging_debug }}"
 

--- a/ansible/roles/solum/defaults/main.yml
+++ b/ansible/roles/solum/defaults/main.yml
@@ -30,24 +30,30 @@ solum_services:
         mode: "http"
         external: false
         port: "{{ solum_application_deployment_port }}"
+        listen_port: "{{ solum_application_deployment_listen_port }}"
         host_group: "solum-application-deployment"
       solum_application_deployment_external:
         enabled: "{{ enable_solum }}"
         mode: "http"
         external: true
-        port: "{{ solum_application_deployment_port }}"
+        external_fqdn: "{{ solum_application_deployment_external_fqdn }}"
+        port: "{{ solum_application_deployment_public_port }}"
+        listen_port: "{{ solum_application_deployment_listen_port }}"
         host_group: "solum-application-deployment"
       solum_image_builder:
         enabled: "{{ enable_solum }}"
         mode: "http"
         external: false
         port: "{{ solum_image_builder_port }}"
+        listen_port: "{{ solum_image_builder_listen_port }}"
         host_group: "solum-image-builder"
       solum_image_builder_external:
         enabled: "{{ enable_solum }}"
         mode: "http"
         external: true
-        port: "{{ solum_image_builder_port }}"
+        external_fqdn: "{{ solum_image_builder_external_fqdn }}"
+        port: "{{ solum_image_builder_public_port }}"
+        listen_port: "{{ solum_image_builder_listen_port }}"
         host_group: "solum-image-builder"
   solum-conductor:
     container_name: solum_conductor
@@ -191,11 +197,11 @@ solum_conductor_extra_volumes: "{{ solum_extra_volumes }}"
 ####################
 # OpenStack
 ####################
-solum_image_builder_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ solum_image_builder_port }}"
-solum_image_builder_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ solum_image_builder_port }}"
+solum_image_builder_internal_endpoint: "{{ solum_image_builder_internal_fqdn | kolla_url(internal_protocol, solum_image_builder_port) }}"
+solum_image_builder_public_endpoint: "{{ solum_image_builder_external_fqdn | kolla_url(public_protocol, solum_image_builder_public_port) }}"
 
-solum_application_deployment_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ solum_application_deployment_port }}"
-solum_application_deployment_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ solum_application_deployment_port }}"
+solum_application_deployment_internal_endpoint: "{{ solum_application_deployment_internal_fqdn | kolla_url(internal_protocol, solum_application_deployment_port) }}"
+solum_application_deployment_public_endpoint: "{{ solum_application_deployment_external_fqdn | kolla_url(public_protocol, solum_application_deployment_public_port) }}"
 
 solum_logging_debug: "{{ openstack_logging_debug }}"
 

--- a/ansible/roles/swift/defaults/main.yml
+++ b/ansible/roles/swift/defaults/main.yml
@@ -13,6 +13,7 @@ swift_services:
         enabled: "{{ enable_swift }}"
         mode: "http"
         external: true
+        external_fqdn: "{{ swift_external_fqdn }}"
         port: "{{ swift_proxy_server_listen_port }}"
 
 ####################

--- a/ansible/roles/tacker/defaults/main.yml
+++ b/ansible/roles/tacker/defaults/main.yml
@@ -15,12 +15,15 @@ tacker_services:
         mode: "http"
         external: false
         port: "{{ tacker_server_port }}"
+        listen_port: "{{ tacker_server_listen_port }}"
         custom_member_list: "{{ tacker_haproxy_members.split(';') }}"
       tacker_server_external:
         enabled: "{{ enable_tacker }}"
         mode: "http"
         external: true
-        port: "{{ tacker_server_port }}"
+        external_fqdn: "{{ tacker_external_fqdn }}"
+        port: "{{ tacker_server_public_port }}"
+        listen_port: "{{ tacker_server_listen_port }}"
         custom_member_list: "{{ tacker_haproxy_members.split(';') }}"
   tacker-conductor:
     container_name: "tacker_conductor"
@@ -127,8 +130,8 @@ tacker_hosts: "{{ [groups['tacker'] | first] }}"
 ####################
 # OpenStack
 ####################
-tacker_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ tacker_server_port }}"
-tacker_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ tacker_server_port }}"
+tacker_internal_endpoint: "{{ tacker_internal_fqdn | kolla_url(internal_protocol, tacker_server_port) }}"
+tacker_public_endpoint: "{{ tacker_external_fqdn | kolla_url(public_protocol, tacker_server_public_port) }}"
 
 tacker_logging_debug: "{{ openstack_logging_debug }}"
 

--- a/ansible/roles/trove/defaults/main.yml
+++ b/ansible/roles/trove/defaults/main.yml
@@ -18,7 +18,10 @@ trove_services:
         enabled: "{{ enable_trove }}"
         mode: "http"
         external: true
-        port: "{{ trove_api_port }}"
+        listen_port: "{{ trove_api_listen_port }}"
+        tls_backend: "{{ trove_enable_tls_backend }}"
+        external_fqdn: "{{ trove_external_fqdn }}"
+        port: "{{ trove_api_public_port }}"
   trove-conductor:
     container_name: trove_conductor
     group: trove-conductor
@@ -148,8 +151,8 @@ trove_taskmanager_extra_volumes: "{{ trove_extra_volumes }}"
 ####################
 # OpenStack
 ####################
-trove_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ trove_api_port }}/v1.0/%(tenant_id)s"
-trove_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ trove_api_port }}/v1.0/%(tenant_id)s"
+trove_internal_endpoint: "{{ trove_internal_fqdn | kolla_url(internal_protocol, trove_api_port, '/v1.0/%(tenant_id)s') }}"
+trove_public_endpoint: "{{ trove_external_fqdn | kolla_url(public_protocol, trove_api_public_port, '/v1.0/%(tenant_id)s') }}"
 
 trove_logging_debug: "{{ openstack_logging_debug }}"
 

--- a/ansible/roles/venus/defaults/main.yml
+++ b/ansible/roles/venus/defaults/main.yml
@@ -18,6 +18,7 @@ venus_services:
         enabled: "{{ enable_venus }}"
         mode: "http"
         external: true
+        external_fqdn: "{{ venus_external_fqdn }}"
         port: "{{ venus_api_port }}"
   venus-manager:
     container_name: venus_manager
@@ -86,8 +87,8 @@ venus_manager_extra_volumes: "{{ venus_extra_volumes }}"
 ####################
 # OpenStack
 ####################
-venus_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ venus_api_port }}/v1.0/%(tenant_id)s"
-venus_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ venus_api_port }}/v1.0/%(tenant_id)s"
+venus_internal_endpoint: "{{ venus_internal_fqdn | kolla_url(internal_protocol, venus_api_port) }}"
+venus_public_endpoint: "{{ venus_external_fqdn | kolla_url(external_protocol, venus_api_port) }}"
 
 venus_logging_debug: "{{ openstack_logging_debug }}"
 

--- a/ansible/roles/vitrage/defaults/main.yml
+++ b/ansible/roles/vitrage/defaults/main.yml
@@ -18,6 +18,7 @@ vitrage_services:
         enabled: "{{ enable_vitrage }}"
         mode: "http"
         external: true
+        external_fqdn: "{{ vitrage_external_fqdn }}"
         port: "{{ vitrage_api_port }}"
   vitrage-notifier:
     container_name: vitrage_notifier

--- a/ansible/roles/watcher/defaults/main.yml
+++ b/ansible/roles/watcher/defaults/main.yml
@@ -14,11 +14,14 @@ watcher_services:
         mode: "http"
         external: false
         port: "{{ watcher_api_port }}"
+        listen_port: "{{ watcher_api_listen_port }}"
       watcher_api_external:
         enabled: "{{ enable_watcher }}"
         mode: "http"
         external: true
-        port: "{{ watcher_api_port }}"
+        external_fqdn: "{{ watcher_external_fqdn }}"
+        port: "{{ watcher_api_public_port }}"
+        listen_port: "{{ watcher_api_listen_port }}"
   watcher-applier:
     container_name: watcher_applier
     group: watcher-applier
@@ -145,8 +148,8 @@ watcher_engine_extra_volumes: "{{ watcher_extra_volumes }}"
 ####################
 # OpenStack
 ####################
-watcher_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ watcher_api_port }}"
-watcher_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ watcher_api_port }}"
+watcher_internal_endpoint: "{{ watcher_internal_fqdn | kolla_url(internal_protocol, watcher_api_port) }}"
+watcher_public_endpoint: "{{ watcher_external_fqdn | kolla_url(public_protocol, watcher_api_public_port) }}"
 
 watcher_logging_debug: "{{ openstack_logging_debug }}"
 

--- a/ansible/roles/zun/defaults/main.yml
+++ b/ansible/roles/zun/defaults/main.yml
@@ -14,11 +14,14 @@ zun_services:
         mode: "http"
         external: false
         port: "{{ zun_api_port }}"
+        listen_port: "{{ zun_api_listen_port }}"
       zun_api_external:
         enabled: "{{ enable_zun }}"
         mode: "http"
         external: true
-        port: "{{ zun_api_port }}"
+        external_fqdn: "{{ zun_external_fqdn }}"
+        port: "{{ zun_api_public_port }}"
+        listen_port: "{{ zun_api_listen_port }}"
   zun-wsproxy:
     container_name: zun_wsproxy
     group: zun-wsproxy
@@ -199,8 +202,8 @@ zun_cni_daemon_extra_volumes: "{{ zun_extra_volumes }}"
 ####################
 ## OpenStack
 ####################
-zun_internal_endpoint: "{{ internal_protocol }}://{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ zun_api_port }}/v1/"
-zun_public_endpoint: "{{ public_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ zun_api_port }}/v1/"
+zun_internal_endpoint: "{{ zun_internal_fqdn | kolla_url(internal_protocol, zun_api_port, '/v1/') }}"
+zun_public_endpoint: "{{ zun_external_fqdn | kolla_url(public_protocol, zun_api_public_port, '/v1/') }}"
 
 zun_logging_debug: "{{ openstack_logging_debug }}"
 

--- a/ansible/roles/zun/templates/zun.conf.j2
+++ b/ansible/roles/zun/templates/zun.conf.j2
@@ -114,7 +114,7 @@ host_shared_with_nova = {{ inventory_hostname in groups['compute'] and enable_no
 [websocket_proxy]
 wsproxy_host = {{ api_interface_address }}
 wsproxy_port = {{ zun_wsproxy_port }}
-base_url = {{ zun_wsproxy_protocol }}://{{ kolla_external_fqdn | put_address_in_context('url') }}:{{ zun_wsproxy_port }}
+base_url = {{ zun_wsproxy_protocol }}://{{ zun_external_fqdn | put_address_in_context('url') }}:{{ zun_wsproxy_port }}
 
 [docker]
 api_url = tcp://{{ api_interface_address | put_address_in_context('url') }}:2375

--- a/doc/source/reference/high-availability/haproxy-guide.rst
+++ b/doc/source/reference/high-availability/haproxy-guide.rst
@@ -22,6 +22,26 @@ setting the following in ``/etc/kolla/globals.yml``:
    enable_haproxy: "no"
    enable_keepalived: "no"
 
+Single external frontend for services
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Single external frontend for particular service can be enabled by adding the
+following in ``/etc/kolla/globals.yml`` (feature and example services):
+
+.. code-block:: yaml
+
+   haproxy_single_external_frontend: true
+
+   nova_external_fqdn: "nova.example.com"
+   neutron_external_fqdn: "neutron.example.com"
+   horizon_external_fqdn: "horizon.example.com"
+   opensearch_external_fqdn: "opensearch.example.com"
+   grafana_external_fqdn: "grafana.example.com"
+
+
+The abovementioned functionality allows for exposing of services on separate
+fqdns on commonly used port i.e. 443 instead of the usual high ports.
+
 Configuration
 ~~~~~~~~~~~~~
 

--- a/kolla_ansible/kolla_url.py
+++ b/kolla_ansible/kolla_url.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2022 StackHPC Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kolla_ansible.put_address_in_context import put_address_in_context
+
+
+def kolla_url(fqdn, protocol, port, path='', context='url'):
+    """generates url
+
+    :param fqdn:
+    :param protocol: http, ws, https or wss
+    :param port: port (omits 80 on http and 443 on https in output)
+    :param path: path - optional
+    :returns: string with url
+    """
+
+    fqdn = put_address_in_context(fqdn, context)
+
+    if ((protocol == 'http' and port == 80) or
+       (protocol == 'https' and port == 443) or
+       (protocol == 'ws' and port == 80) or
+       (protocol == 'wss' and port == 443)):
+        address = f"{protocol}://{fqdn}{path}"
+    else:
+        address = f"{protocol}://{fqdn}:{port}{path}"
+
+    return address

--- a/kolla_ansible/tests/unit/test_address_filters.py
+++ b/kolla_ansible/tests/unit/test_address_filters.py
@@ -20,6 +20,7 @@ import jinja2
 
 from kolla_ansible.exception import FilterError
 from kolla_ansible.kolla_address import kolla_address
+from kolla_ansible.kolla_url import kolla_url
 from kolla_ansible.put_address_in_context import put_address_in_context
 
 from kolla_ansible.tests.unit.helpers import _to_bool
@@ -323,3 +324,66 @@ class TestKollaAddressFilter(unittest.TestCase):
             },
         })
         self.assertEqual(addr, kolla_address(context, 'api'))
+
+
+class TestKollaUrlFilter(unittest.TestCase):
+
+    def test_https_443_path(self):
+        protocol = 'https'
+        fqdn = 'kolla.external'
+        port = 443
+        path = '/v2'
+        self.assertEqual("https://kolla.external/v2",
+                         kolla_url(fqdn, protocol, port, path))
+
+    def test_http_80_path(self):
+        protocol = 'http'
+        fqdn = 'kolla.external'
+        port = 80
+        path = '/v2'
+        self.assertEqual("http://kolla.external/v2",
+                         kolla_url(fqdn, protocol, port, path))
+
+    def test_https_8443_path(self):
+        protocol = 'https'
+        fqdn = 'kolla.external'
+        port = 8443
+        path = '/v2'
+        self.assertEqual("https://kolla.external:8443/v2",
+                         kolla_url(fqdn, protocol, port, path))
+
+    def test_http_8080_path(self):
+        protocol = 'http'
+        fqdn = 'kolla.external'
+        port = 8080
+        path = '/v2'
+        self.assertEqual("http://kolla.external:8080/v2",
+                         kolla_url(fqdn, protocol, port, path))
+
+    def test_https_443_nopath(self):
+        protocol = 'https'
+        fqdn = 'kolla.external'
+        port = 443
+        self.assertEqual("https://kolla.external",
+                         kolla_url(fqdn, protocol, port))
+
+    def test_http_80_nopath(self):
+        protocol = 'http'
+        fqdn = 'kolla.external'
+        port = 80
+        self.assertEqual("http://kolla.external",
+                         kolla_url(fqdn, protocol, port))
+
+    def test_https_8443_nopath(self):
+        protocol = 'https'
+        fqdn = 'kolla.external'
+        port = 8443
+        self.assertEqual("https://kolla.external:8443",
+                         kolla_url(fqdn, protocol, port))
+
+    def test_http_8080_nopath(self):
+        protocol = 'http'
+        fqdn = 'kolla.external'
+        port = 8080
+        self.assertEqual("http://kolla.external:8080",
+                         kolla_url(fqdn, protocol, port))

--- a/releasenotes/notes/haproxy-single-external-frontend-7dadd1fff8a8dfbd.yaml
+++ b/releasenotes/notes/haproxy-single-external-frontend-7dadd1fff8a8dfbd.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Adds single service external frontend feature to haproxy.
+    Details are in the
+    `haproxy guide <https://docs.openstack.org/kolla-ansible/latest/reference/high-availability/haproxy-guide.html>`_
+    section of the documentation.


### PR DESCRIPTION
Use case: exposing single external https frontend and load balancing services using FQDNs.

Support different ports for internal and external endpoints.

Introduced kolla_url filter to normalize urls like:
- https://magnum.external:443/v1
- http://magnum.external:80/v1

Change-Id: I9fb03fe1cebce5c7198d523e015280c69f139cd0
Co-Authored-By: Jakub Darmach <jakub@stackhpc.com>
(cherry picked from commit 4bc410c6cacba3801f432c755bb3f5cd5781ca26)