### PR TITLE
Conditionally deploy caso

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1017,4 +1017,5 @@
   serial: '{{ kolla_serial|default("0") }}'
   roles:
     - { role: caso,
-        tags: caso}
+        tags: caso,
+        when: enable_caso | bool }


### PR DESCRIPTION
The missing when means that we always deploy caso.