### PR TITLE
Conditionally deploy caso

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -974,5 +974,5 @@
   serial: '{{ kolla_serial|default("0") }}'
   roles:
     - { role: caso,
-        tags: caso}
-
+        tags: caso,
+        when: enable_caso | bool }


### PR DESCRIPTION
The missing when means that we always deploy caso.

Change-Id: Icd95a86e6443a478708900324a68a2855d6f3837