### PR TITLE
Fix nova DB password rotation

### DIFF
--- a/ansible/roles/nova/tasks/bootstrap_service.yml
+++ b/ansible/roles/nova/tasks/bootstrap_service.yml
@@ -1,12 +1,11 @@
 ---
-# TODO(mgoddard): We could use nova-manage db sync --local_cell, otherwise we
-# sync cell0 twice. Should not be harmful without though.
 - name: Running Nova API bootstrap container
   become: true
   vars:
     nova_api: "{{ nova_services['nova-api'] }}"
   kolla_docker:
     action: "start_container"
+    command: bash -c 'sudo -E kolla_set_configs && nova-manage api_db sync && nova-manage db sync --local_cell'
     common_options: "{{ docker_common_options }}"
     detach: False
     environment:


### PR DESCRIPTION
The nova API bootstrap container fails to boot when the nova database password is changed without the `--local-cell` argument for the nova DB sync.

I am planning on changing the default upstream to fix this but for now it is best to manually override the boot command.