### PR TITLE
Fix services config in single external frontend

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -363,6 +363,7 @@ gnocchi_internal_fqdn: "{{ kolla_internal_fqdn }}"
 gnocchi_external_fqdn: "{{ kolla_external_fqdn }}"
 gnocchi_api_port: "8041"
 gnocchi_api_listen_port: "{{ gnocchi_api_port }}"
+gnocchi_api_public_port: "{{ haproxy_single_external_frontend_public_port if haproxy_single_external_frontend | bool else gnocchi_api_port }}"
 
 grafana_internal_fqdn: "{{ kolla_internal_fqdn }}"
 grafana_external_fqdn: "{{ kolla_external_fqdn }}"

--- a/ansible/roles/venus/defaults/main.yml
+++ b/ansible/roles/venus/defaults/main.yml
@@ -19,7 +19,7 @@ venus_services:
         mode: "http"
         external: true
         external_fqdn: "{{ venus_external_fqdn }}"
-        port: "{{ venus_api_port }}"
+        port: "{{ venus_api_public_port }}"
   venus-manager:
     container_name: venus_manager
     group: venus-manager

--- a/ansible/roles/vitrage/defaults/main.yml
+++ b/ansible/roles/vitrage/defaults/main.yml
@@ -19,7 +19,7 @@ vitrage_services:
         mode: "http"
         external: true
         external_fqdn: "{{ vitrage_external_fqdn }}"
-        port: "{{ vitrage_api_port }}"
+        port: "{{ vitrage_api_public_port }}"
   vitrage-notifier:
     container_name: vitrage_notifier
     group: vitrage-notifier


### PR DESCRIPTION
Adding missing group_vars for gnocchi service.
Using proper variables in haproxy config for vitrage and venus services.

Closes-Bug: #2038904
Change-Id: I06e8f29440c13864a866ea03ce0a0821fbe846f8 (cherry picked from commit 8fb0bddfe92404ddb39154a353eba9ba4805b5f1)