### PR TITLE
Revert "Fix nova DB password rotation"

### DIFF
--- a/ansible/roles/nova/tasks/bootstrap_service.yml
+++ b/ansible/roles/nova/tasks/bootstrap_service.yml
@@ -1,11 +1,12 @@
 ---
+# TODO(mgoddard): We could use nova-manage db sync --local_cell, otherwise we
+# sync cell0 twice. Should not be harmful without though.
 - name: Running Nova API bootstrap container
   become: true
   vars:
     nova_api: "{{ nova_services['nova-api'] }}"
   kolla_docker:
     action: "start_container"
-    command: bash -c 'sudo -E kolla_set_configs && nova-manage api_db sync && nova-manage db sync --local_cell'
     common_options: "{{ docker_common_options }}"
     detach: False
     environment:


### PR DESCRIPTION
Reverts stackhpc/kolla-ansible#494

It was found to cause an issue when bootstrapping nova API in fresh deployments:

    TASK [nova : Running Nova API bootstrap container]
    FileNotFoundError: [Errno 2] No such file or directory: '/var/log/kolla/nova/nova-manage.log'

We can wait for the upstream fix[1] to arrive in our images.

[1] https://review.opendev.org/c/openstack/kolla/+/902057