### PR TITLE
Antelope: Adjust Ceph metrics scrape interval in Prometheus

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1256,6 +1256,7 @@ enable_prometheus_etcd_integration: "{{ enable_prometheus | bool and enable_etcd
 enable_prometheus_msteams: "no"
 
 prometheus_alertmanager_user: "admin"
+prometheus_ceph_exporter_interval: "15s"
 prometheus_grafana_user: "grafana"
 prometheus_scrape_interval: "60s"
 prometheus_openstack_exporter_interval: "{{ prometheus_scrape_interval }}"

--- a/ansible/roles/prometheus/templates/prometheus.yml.j2
+++ b/ansible/roles/prometheus/templates/prometheus.yml.j2
@@ -125,6 +125,7 @@ scrape_configs:
 {% if enable_prometheus_ceph_mgr_exporter | bool %}
   - job_name: ceph_mgr_exporter
     honor_labels: true
+    scrape_interval: {{ prometheus_ceph_exporter_interval }}
     static_configs:
       - targets:
 {% for exporter in prometheus_ceph_mgr_exporter_endpoints %}

--- a/releasenotes/notes/add-ceph-metrics-scrape-interval-3ee39fba696860e9.yaml
+++ b/releasenotes/notes/add-ceph-metrics-scrape-interval-3ee39fba696860e9.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds a new variable for controlling Ceph's metrics scrape interval and
+    sets it to recommended 15s value.


### PR DESCRIPTION
Enables modifying the interval and sets the recommended default value.

[1] https://docs.ceph.com/en/latest/mgr/prometheus/#configuration

Change-Id: I4b91d184485aa52b3c06011f9dbb6b34bcad3ca8