### PR TITLE
Fix ansible requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -2,4 +2,4 @@
 collections:
   - name: https://opendev.org/openstack/ansible-collection-kolla
     type: git
-    version: stable/yoga
+    version: unmaintained/yoga


### PR DESCRIPTION
The stable/yoga branch for ansible-collection-kolla no longer exists. This change corrects the reference in requirements.yml to unmaintained/yoga
