### PR TITLE
Change kolla_container to kolla_docker

### DIFF
--- a/ansible/roles/grafana/tasks/post_config.yml
+++ b/ansible/roles/grafana/tasks/post_config.yml
@@ -15,7 +15,7 @@
 
 - name: Remove old grafana docker volume
   become: true
-  kolla_container:
+  kolla_docker:
     action: "remove_volume"
     name: grafana
   when: grafana_remove_old_volume | bool


### PR DESCRIPTION
Backporting 8a449a143a977fe6d13bc684dd4d56433181a352 resulted in kolla_container being brought into the repo which breaks grafana kolla tasks. This is a fix for that. 