### PR TITLE
Opensearch grafana plugin config

### DIFF
--- a/ansible/roles/grafana/defaults/main.yml
+++ b/ansible/roles/grafana/defaults/main.yml
@@ -69,6 +69,7 @@ grafana_data_sources:
         database: "{{ opensearch_log_index_prefix }}-*"
         version: "2.11.1"
         timeField: "@timestamp"
+        logLevelField: "log_level"
 
 ##########
 # Grafana

--- a/ansible/roles/grafana/defaults/main.yml
+++ b/ansible/roles/grafana/defaults/main.yml
@@ -65,9 +65,9 @@ grafana_data_sources:
       access: "proxy"
       url: "{{ opensearch_internal_endpoint }}"
       jsonData:
-        flavor: "elasticsearch"
-        database: "[flog-]YYYY.MM.DD"
-        version: "7.0.0"
+        flavor: "OpenSearch"
+        database: "{{ opensearch_log_index_prefix }}-*"
+        version: "2.11.1"
         timeField: "@timestamp"
 
 ##########

--- a/releasenotes/notes/grafana-openseach-add-log-level-d64e304977d4f550.yaml
+++ b/releasenotes/notes/grafana-openseach-add-log-level-d64e304977d4f550.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Configures the log level field for the Grafana OpenSearch datasource. This
+    allows for logs to be coloured based on log level. To apply this you need
+    to delete the datasource and reconfigure grafana.

--- a/releasenotes/notes/grafana-opensearch-datasource-configuration-04202c059f1abd05.yaml
+++ b/releasenotes/notes/grafana-opensearch-datasource-configuration-04202c059f1abd05.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Updates the default Grafana OpenSearch datasource configuration to use
+    values for OpenSearch that work out of the box. Replaces the Elasticsearch
+    values that were previously being used. The new configuration can be
+    applied by deleting your datasource and reconfiguring Grafana through kolla
+    ansible. In order to prevent dashboards from breaking when the datasource
+    is deleted, one should use `datasource variables
+    <https://grafana.com/docs/grafana/latest/dashboards/variables/add-template-variables/#add-a-data-source-variable>`__
+    in Grafana. See bug `2039500 <https://bugs.launchpad.net/kolla-ansible/+bug/2039500>`__.


### PR DESCRIPTION
Changes needed to configure the opensearch plugin in grafana when first configuring it. As mentioned in the release note:
```
 To apply this you need to delete the datasource and reconfigure grafana.