### PR TITLE
kolla_url: port is a string

### DIFF
--- a/kolla_ansible/kolla_url.py
+++ b/kolla_ansible/kolla_url.py
@@ -28,6 +28,7 @@ def kolla_url(fqdn, protocol, port, path='', context='url'):
     """
 
     fqdn = put_address_in_context(fqdn, context)
+    port = int(port)
 
     if ((protocol == 'http' and port == 80) or
        (protocol == 'https' and port == 443) or


### PR DESCRIPTION
Ansible passes port as a string - therefore matching does not work and we get https://nova_url:443/v2.1

Closes-Bug: #2063434

Change-Id: I76cce7f491c77b6b788d29c8644e87055f5cfff0