### PR TITLE
fix: use `zed-eol` for `ansible-collection-kolla`

### DIFF
--- a/releasenotes/notes/bump-kolla-collection-zed-eol-2f08a0985b1ad6fb.yaml
+++ b/releasenotes/notes/bump-kolla-collection-zed-eol-2f08a0985b1ad6fb.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Use ``zed-eol`` tag for ``ansible-collection-kolla`` as the
+    ``unmaintained/zed`` branch has been deleted.
+

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,4 +2,4 @@
 collections:
   - name: https://opendev.org/openstack/ansible-collection-kolla
     type: git
-    version: unmaintained/zed
+    version: zed-eol


### PR DESCRIPTION
Use ``zed-eol`` tag for ``ansible-collection-kolla`` as the ``unmaintained/zed`` branch has been deleted.