### PR TITLE
Correct mariadb restart handlers

### DIFF
--- a/ansible/roles/mariadb/handlers/main.yml
+++ b/ansible/roles/mariadb/handlers/main.yml
@@ -60,7 +60,7 @@
     - groups[mariadb_shard_group + '_port_alive_True'] is defined
     - inventory_hostname in groups[mariadb_shard_group + '_port_alive_True']
     - kolla_action != "config"
-  listen: restart mariadb
+  listen: Restart mariadb container
 
 - name: Start MariaDB on new nodes
   group_by:
@@ -70,7 +70,7 @@
     - groups[mariadb_shard_group + '_port_alive_False'] is defined
     - inventory_hostname in groups[mariadb_shard_group + '_port_alive_False']
     - kolla_action != "config"
-  listen: restart mariadb
+  listen: Restart mariadb container
 
 - name: Restart mariadb-clustercheck container
   vars:

--- a/ansible/roles/mariadb/tasks/config.yml
+++ b/ansible/roles/mariadb/tasks/config.yml
@@ -44,7 +44,7 @@
   become: true
   with_dict: "{{ mariadb_services | select_services_enabled_and_mapped_to_host }}"
   notify:
-    - "restart {{ item.key }}"
+    - "Restart {{ item.key }} container"
 
 - name: Copying over config.json files for mariabackup
   vars:
@@ -72,4 +72,4 @@
   become: true
   when: service | service_enabled_and_mapped_to_host
   notify:
-    - restart mariadb
+    - Restart mariadb container


### PR DESCRIPTION
This was removed in 65325d96876afcec4707852f5de258bdfd2b7912 but it is still called by the config playbook.

Change-Id: Idfb5b814e16056d439cf1e1318f86bbcea82d981