### PR TITLE
Antelope: Fix internal TLS certificate not copied

### DIFF
--- a/ansible/roles/loadbalancer/tasks/config.yml
+++ b/ansible/roles/loadbalancer/tasks/config.yml
@@ -236,7 +236,6 @@
     mode: "0660"
   become: true
   when:
-    - not enable_letsencrypt | bool
     - kolla_enable_tls_internal | bool
     - not kolla_externally_managed_cert | bool
     - inventory_hostname in groups[service.group]

--- a/ansible/roles/loadbalancer/templates/haproxy/haproxy.json.j2
+++ b/ansible/roles/loadbalancer/templates/haproxy/haproxy.json.j2
@@ -33,13 +33,13 @@
             "perm": "0600",
             "optional": {{ (not kolla_enable_tls_external | bool) | string | lower }}
         }{% endif %}
-        {% if kolla_enable_tls_internal | bool and not enable_letsencrypt | bool %},
+        {% if kolla_enable_tls_internal | bool %},
         {
             "source": "{{ container_config_directory }}/haproxy-internal.pem",
             "dest": "/etc/haproxy/certificates/haproxy-internal.pem",
             "owner": "haproxy",
             "perm": "0600",
-            "optional": {{ (not kolla_enable_tls_internal | bool) | string | lower }}
+            "optional": {{ (enable_letsencrypt | bool) | string | lower }}
         }
         {% endif %}
     ]

--- a/releasenotes/notes/fix-internal-tls-when-using-le-6b633cd2086e44c6.yaml
+++ b/releasenotes/notes/fix-internal-tls-when-using-le-6b633cd2086e44c6.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes an issue with internal TLS certificate not being copied to HAproxy
+    container when Let's Encrypt is enabled.


### PR DESCRIPTION
This is present within `stackhpc/2024.1` and is required for environments that use internal TLS and also use Let's Encrypt for public [1].

1. https://github.com/stackhpc/kolla-ansible/pull/653

Closes-bug: #2076331
Change-Id: Id80c7823fcc5d934b7369c7c0722cd78188e2ccf