### PR TITLE
Migrate distutils functions to setuptools

### DIFF
--- a/ansible/library/kolla_toolbox.py
+++ b/ansible/library/kolla_toolbox.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from distutils.version import StrictVersion
 import json
 import re
 
@@ -20,6 +19,7 @@ from ansible.module_utils.ansible_release import __version__ as ansible_version
 from ansible.module_utils.basic import AnsibleModule
 
 from ast import literal_eval
+from pkg_resources import parse_version
 from shlex import split
 
 DOCUMENTATION = '''
@@ -117,7 +117,7 @@ def gen_commandline(params):
     if params.get('module_name'):
         command.extend(['-m', params.get('module_name')])
     if params.get('module_args'):
-        if StrictVersion(ansible_version) < StrictVersion('2.11.0'):
+        if parse_version(ansible_version) < parse_version('2.11.0'):
             module_args = params.get('module_args')
         else:
             try:
@@ -148,8 +148,8 @@ def get_docker_client():
 
 
 def docker_supports_environment_in_exec(client):
-    docker_version = StrictVersion(client.api_version)
-    return docker_version >= StrictVersion('1.25')
+    docker_version = parse_version(client.api_version)
+    return docker_version >= parse_version('1.25')
 
 
 def use_docker(module):

--- a/ansible/module_utils/kolla_docker_worker.py
+++ b/ansible/module_utils/kolla_docker_worker.py
@@ -18,8 +18,7 @@ import os
 
 from ansible.module_utils.kolla_container_worker import COMPARE_CONFIG_CMD
 from ansible.module_utils.kolla_container_worker import ContainerWorker
-
-from distutils.version import StrictVersion
+from pkg_resources import parse_version
 
 
 def get_docker_client():
@@ -39,9 +38,9 @@ class DockerWorker(ContainerWorker):
         self.dc = get_docker_client()(**options)
 
         self._cgroupns_mode_supported = (
-            StrictVersion(self.dc._version) >= StrictVersion('1.41'))
+            parse_version(self.dc._version) >= parse_version('1.41'))
         self._dimensions_kernel_memory_removed = (
-            StrictVersion(self.dc._version) >= StrictVersion('1.42'))
+            parse_version(self.dc._version) >= parse_version('1.42'))
 
         if self._dimensions_kernel_memory_removed:
             self.dimension_map.pop('kernel_memory', None)


### PR DESCRIPTION
Python module distutils has been deprecated from python 3.10 and not available from python 3.12.

Since Ubuntu 24.04 (which uses python 3.12) is now supported with https://review.opendev.org/c/openstack/kolla-ansible/+/932539 , Python codes that uses distutils fails when K-A is run on Ubuntu Noble.

Preventing this by replacing distutils.version.StrictVersion() to setuptools.parse_version().

Closes-bug: #2106487
Change-Id: I68cef58ad6298cb987b07aac18b80d4a5e0de4ee (cherry picked from commit 3651d515601bf9118440f5b41fe71258b8304519)