### PR TITLE
Fix Nova and Cinder external ceph enabled check

### DIFF
--- a/ansible/roles/nova-cell/tasks/external_ceph.yml
+++ b/ansible/roles/nova-cell/tasks/external_ceph.yml
@@ -151,7 +151,9 @@
         group: "{{ config_owner_group }}"
         mode: "0600"
       become: true
-      when: service | service_enabled_and_mapped_to_host
+      when:
+        - service | service_enabled_and_mapped_to_host
+        - item.enabled | bool
       with_items:
         - uuid: "{{ rbd_secret_uuid }}"
           name: "client.nova secret"

--- a/releasenotes/notes/fix-nova-backend-rbd-group-var-3c057daa084c0612.yaml
+++ b/releasenotes/notes/fix-nova-backend-rbd-group-var-3c057daa084c0612.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes case where the Ceph secret XMLs for Nova and
+    Cinder were always pushed to hosts, even when
+    nova_backend was not "rbd" and cinder_backend_ceph
+    was False.


### PR DESCRIPTION
Restore checks that nova_backend == 'rbd' and
cinder_backend_ceph before pushing libvirt secret
xmls for both services. Removed in [1].

Note we backported [1] to stackhpc/2024.1 allow us to do the ovn-sb-proxy stuff.

[1] https://review.opendev.org/c/openstack/kolla-ansible/+/914997

Closes-Bug: #2106720
Change-Id: Ib0a557adc4b9f8349d54e6e243270e8195dd39e5 (cherry picked from commit da12a4be7b8a9b7939621a65d830d26606fc9f9a)

