### PR TITLE
Replace ipaddr with ansible.utils.ipaddr

### DIFF
--- a/ansible/roles/loadbalancer/tasks/precheck.yml
+++ b/ansible/roles/loadbalancer/tasks/precheck.yml
@@ -191,7 +191,7 @@
   changed_when: false
   failed_when: >-
     ( ip_addr_output is failed or
-     kolla_internal_vip_address | ipaddr(ip_addr_output.stdout.split()[3]) is none)
+     kolla_internal_vip_address | ansible.utils.ipaddr(ip_addr_output.stdout.split()[3]) is none)
   check_mode: false
   when:
     - enable_haproxy | bool

--- a/ansible/roles/ovs-dpdk/defaults/main.yml
+++ b/ansible/roles/ovs-dpdk/defaults/main.yml
@@ -40,7 +40,7 @@ ovsdpdk_services:
 ovs_bridge_mappings: "{% for bridge in neutron_bridge_name.split(',') %}physnet{{ loop.index0 + 1 }}:{{ bridge }}{% if not loop.last %},{% endif %}{% endfor %}"
 ovs_port_mappings: "{% for bridge in neutron_bridge_name.split(',') %} {{ neutron_external_interface.split(',')[loop.index0] }}:{{ bridge }}{% if not loop.last %},{% endif %}{% endfor %}"
 tunnel_interface_network: "{{ hostvars[inventory_hostname].ansible_facts[dpdk_tunnel_interface]['ipv4']['network'] }}/{{ hostvars[inventory_hostname].ansible_facts[dpdk_tunnel_interface]['ipv4']['netmask'] }}"
-tunnel_interface_cidr: "{{ dpdk_tunnel_interface_address }}/{{ tunnel_interface_network | ipaddr('prefix') }}"
+tunnel_interface_cidr: "{{ dpdk_tunnel_interface_address }}/{{ tunnel_interface_network | ansible.utils.ipaddr('prefix') }}"
 ovs_cidr_mappings: "{% if neutron_bridge_name.split(',') | length != 1 %} {neutron_bridge_name.split(',')[0]}:{{ tunnel_interface_cidr }} {% else %} {{ neutron_bridge_name }}:{{ tunnel_interface_cidr }} {% endif %}"
 ovs_mem_channels: 4
 ovs_socket_mem: 1024

--- a/roles/multi-node-managed-addressing/tasks/main.yml
+++ b/roles/multi-node-managed-addressing/tasks/main.yml
@@ -20,7 +20,7 @@
     # otherwise bifrost fails its pre-bootstrap sanity checks due to missing
     # broadcast address as ansible picks up scope ('global') as the interface's
     # broadcast address which fails checks logic
-    managed_network_broadcast_address: "{{ managed_network_cidr | ipaddr('broadcast') }}"
+    managed_network_broadcast_address: "{{ managed_network_cidr | ansible.utils.ipaddr('broadcast') }}"
   command: ip address add {{ managed_network_cidr }} broadcast {{ managed_network_broadcast_address }} dev {{ managed_interface_name }}
   when: managed_network_address_family == 'ipv4'
 


### PR DESCRIPTION
Cherry-picked back to Antelope upstream, required in Zed downstream

[DEPRECATION WARNING]: Filter "ansible.netcommon.ipaddr" has been deprecated. Use 'ansible.utils.ipaddr' module instead. This feature will be removed from ansible.netcommon in a release after 2024-01-01.
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

Change-Id: Ibcef3e642e5ff87aab6d8f73bda9860016cf715a