### PR TITLE
Revert "Migrate distutils functions to setuptools"

### DIFF
--- a/ansible/library/kolla_toolbox.py
+++ b/ansible/library/kolla_toolbox.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from distutils.version import StrictVersion
 import json
 import re
 
@@ -19,7 +20,6 @@ from ansible.module_utils.ansible_release import __version__ as ansible_version
 from ansible.module_utils.basic import AnsibleModule
 
 from ast import literal_eval
-from pkg_resources import parse_version
 from shlex import split
 
 DOCUMENTATION = '''
@@ -117,7 +117,7 @@ def gen_commandline(params):
     if params.get('module_name'):
         command.extend(['-m', params.get('module_name')])
     if params.get('module_args'):
-        if parse_version(ansible_version) < parse_version('2.11.0'):
+        if StrictVersion(ansible_version) < StrictVersion('2.11.0'):
             module_args = params.get('module_args')
         else:
             try:
@@ -148,8 +148,8 @@ def get_docker_client():
 
 
 def docker_supports_environment_in_exec(client):
-    docker_version = parse_version(client.api_version)
-    return docker_version >= parse_version('1.25')
+    docker_version = StrictVersion(client.api_version)
+    return docker_version >= StrictVersion('1.25')
 
 
 def use_docker(module):

--- a/ansible/module_utils/kolla_docker_worker.py
+++ b/ansible/module_utils/kolla_docker_worker.py
@@ -18,7 +18,8 @@ import os
 
 from ansible.module_utils.kolla_container_worker import COMPARE_CONFIG_CMD
 from ansible.module_utils.kolla_container_worker import ContainerWorker
-from pkg_resources import parse_version
+
+from distutils.version import StrictVersion
 
 
 def get_docker_client():
@@ -38,9 +39,9 @@ class DockerWorker(ContainerWorker):
         self.dc = get_docker_client()(**options)
 
         self._cgroupns_mode_supported = (
-            parse_version(self.dc._version) >= parse_version('1.41'))
+            StrictVersion(self.dc._version) >= StrictVersion('1.41'))
         self._dimensions_kernel_memory_removed = (
-            parse_version(self.dc._version) >= parse_version('1.42'))
+            StrictVersion(self.dc._version) >= StrictVersion('1.42'))
 
         if self._dimensions_kernel_memory_removed:
             self.dimension_map.pop('kernel_memory', None)


### PR DESCRIPTION
Reverts stackhpc/kolla-ansible#704

The upstream change https://github.com/stackhpc/kolla-ansible/pull/731/commits/60caa7a7076ef05686222195ffaa866a2c76adc0 fixes the same problem but in different way. Need to revert downstream changes