### PR TITLE
Run ML2/OVS agents processes in separate containers

### DIFF
--- a/ansible/roles/neutron/defaults/main.yml
+++ b/ansible/roles/neutron/defaults/main.yml
@@ -66,6 +66,7 @@ neutron_services:
     dimensions: "{{ neutron_linuxbridge_agent_dimensions }}"
     healthcheck: "{{ neutron_linuxbridge_agent_healthcheck }}"
   neutron-dhcp-agent:
+    cgroupns_mode: "{{ 'host' if neutron_agents_wrappers | bool else 'private' }}"
     container_name: "neutron_dhcp_agent"
     image: "{{ neutron_dhcp_agent_image_full }}"
     privileged: True
@@ -75,13 +76,22 @@ neutron_services:
     volumes: "{{ neutron_dhcp_agent_default_volumes + neutron_dhcp_agent_extra_volumes }}"
     dimensions: "{{ neutron_dhcp_agent_dimensions }}"
     healthcheck: "{{ neutron_dhcp_agent_healthcheck }}"
+    pid_mode: "{{ 'host' if neutron_agents_wrappers | bool else '' }}"
+    environment:
+      KOLLA_IMAGE: "{{ neutron_dhcp_agent_image_full }}"
+      KOLLA_NAME: "neutron_dhcp_agent"
+      KOLLA_NEUTRON_WRAPPERS: "{{ 'true' if neutron_agents_wrappers | bool else 'false' }}"
   neutron-l3-agent:
+    cgroupns_mode: "{{ 'host' if neutron_agents_wrappers | bool else 'private' }}"
     container_name: "neutron_l3_agent"
     image: "{{ neutron_l3_agent_image_full }}"
     privileged: True
     enabled: "{{ neutron_plugin_agent not in ['ovn', 'vmware_nsxv', 'vmware_nsxv3', 'vmware_nsxp', 'vmware_dvs'] }}"
     environment:
+      KOLLA_IMAGE: "{{ neutron_l3_agent_image_full }}"
       KOLLA_LEGACY_IPTABLES: "{{ neutron_legacy_iptables | bool | lower }}"
+      KOLLA_NAME: "neutron_l3_agent"
+      KOLLA_NEUTRON_WRAPPERS: "{{ 'true' if neutron_agents_wrappers | bool else 'false' }}"
     host_in_groups: >-
       {{
       inventory_hostname in groups['neutron-l3-agent']
@@ -90,6 +100,8 @@ neutron_services:
     volumes: "{{ neutron_l3_agent_default_volumes + neutron_l3_agent_extra_volumes }}"
     dimensions: "{{ neutron_l3_agent_dimensions }}"
     healthcheck: "{{ neutron_l3_agent_healthcheck }}"
+    pid_mode: "{{ 'host' if neutron_agents_wrappers | bool else '' }}"
+
   neutron-sriov-agent:
     container_name: "neutron_sriov_agent"
     image: "{{ neutron_sriov_agent_image_full }}"
@@ -511,6 +523,9 @@ neutron_dhcp_agent_default_volumes:
   - "kolla_logs:/var/log/kolla/"
   - "{{ '/dev/shm:/dev/shm' if om_enable_queue_manager | bool else '' }}"
   - "{{ kolla_dev_repos_directory ~ '/neutron/neutron:/var/lib/kolla/venv/lib/python' ~ distro_python_version ~ '/site-packages/neutron' if neutron_dev_mode | bool else '' }}"
+  - "{{ '/var/run/docker.sock:/var/run/docker.sock:ro' if neutron_agents_wrappers | bool and kolla_container_engine == 'docker' }}"
+  - "{{ '/run/podman/podman.sock:/run/podman/podman.sock' if neutron_agents_wrappers | bool and kolla_container_engine == 'podman' }}"
+  - "{{ '/var/lib/containers:/var/lib/containers' if neutron_agents_wrappers | bool and kolla_container_engine == 'podman' }}"
 neutron_l3_agent_default_volumes:
   - "{{ node_config_directory }}/neutron-l3-agent/:{{ container_config_directory }}/:ro"
   - "/etc/localtime:/etc/localtime:ro"
@@ -521,6 +536,9 @@ neutron_l3_agent_default_volumes:
   - "kolla_logs:/var/log/kolla/"
   - "{{ '/dev/shm:/dev/shm' if om_enable_queue_manager | bool else '' }}"
   - "{{ kolla_dev_repos_directory ~ '/neutron/neutron:/var/lib/kolla/venv/lib/python' ~ distro_python_version ~ '/site-packages/neutron' if neutron_dev_mode | bool else '' }}"
+  - "{{ '/var/run/docker.sock:/var/run/docker.sock:ro' if neutron_agents_wrappers | bool and kolla_container_engine == 'docker' }}"
+  - "{{ '/run/podman/podman.sock:/run/podman/podman.sock' if neutron_agents_wrappers | bool and kolla_container_engine == 'podman' }}"
+  - "{{ '/var/lib/containers:/var/lib/containers' if neutron_agents_wrappers | bool and kolla_container_engine == 'podman' }}"
 neutron_sriov_agent_default_volumes:
   - "{{ node_config_directory }}/neutron-sriov-agent/:{{ container_config_directory }}/:ro"
   - "/etc/localtime:/etc/localtime:ro"
@@ -667,6 +685,8 @@ neutron_l3_agent_host_ipv6_neigh_gc_thresh3: "{{ neutron_l3_agent_host_ipv4_neig
 
 neutron_api_workers: "{{ openstack_service_workers }}"
 neutron_metadata_workers: "{{ openstack_service_workers }}"
+
+neutron_agents_wrappers: "no"
 
 ####################
 # Subprojects

--- a/ansible/roles/neutron/handlers/main.yml
+++ b/ansible/roles/neutron/handlers/main.yml
@@ -84,6 +84,9 @@
     dimensions: "{{ service.dimensions }}"
     privileged: "{{ service.privileged | default(False) }}"
     healthcheck: "{{ service.healthcheck | default(omit) }}"
+    pid_mode: "{{ service.pid_mode | default(omit) }}"
+    cgroupns_mode: "{{ service.cgroupns_mode | default(omit) }}"
+    environment: "{{ service.environment | default(omit) }}"
   when:
     - kolla_action != "config"
 
@@ -118,6 +121,8 @@
     dimensions: "{{ service.dimensions }}"
     privileged: "{{ service.privileged | default(False) }}"
     healthcheck: "{{ service.healthcheck | default(omit) }}"
+    pid_mode: "{{ service.pid_mode | default(omit) }}"
+    cgroupns_mode: "{{ service.cgroupns_mode | default(omit) }}"
   when:
     - kolla_action != "config"
     - groups['neutron_l3_agent_running_False'] is defined
@@ -148,6 +153,8 @@
     dimensions: "{{ service.dimensions }}"
     privileged: "{{ service.privileged | default(False) }}"
     healthcheck: "{{ service.healthcheck | default(omit) }}"
+    pid_mode: "{{ service.pid_mode | default(omit) }}"
+    cgroupns_mode: "{{ service.cgroupns_mode | default(omit) }}"
   when:
     - kolla_action != "config"
     - inventory_hostname == item

--- a/doc/source/reference/networking/neutron.rst
+++ b/doc/source/reference/networking/neutron.rst
@@ -335,3 +335,18 @@ In this example:
 - `neutron_modules_extra`: Allows users to specify additional modules and
   their associated parameters. The given configuration adjusts the
   `hashsize` parameter for the `nf_conntrack_tftp` module.
+
+Running Neutron agents subprocesses in separate containers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There is an experimental feature in Kolla-Ansible that allows to overcome
+the issue of breaking data plane connectivity and dhcp services when
+restarting neutron-l3-agent and neutron-dhcp-agent.
+
+To enable it, modify the configuration in ``/etc/kolla/globals.yml``:
+
+.. code-block:: yaml
+
+   neutron_agents_wrappers: "yes"
+
+For additional details see `bug 1891469 <https://launchpad.net/bugs/1891469>`_

--- a/releasenotes/notes/bug-1891469-4f8a45c29bde55e5.yaml
+++ b/releasenotes/notes/bug-1891469-4f8a45c29bde55e5.yaml
@@ -1,0 +1,13 @@
+---
+fixes:
+  - |
+    Implements ``neutron_agents_wrappers`` which can be used to overcome
+    ``neutron-l3-agent``/``neutron-dhcp-agent`` restart causing data plane
+    interruptions.
+    The neutron agents use subprocesses like dnsmasq and keepalived as part
+    of their implementation. Running these "subprocesses" in separate
+    containers prevents dataplane breakages/unnecessary failover on agent
+    container restart.
+    This new behaviour can be enabled by setting ``neutron_agents_wrappers``
+    to ``yes``.
+    `LP#1891469 <https://launchpad.net/bugs/1891469>`__

--- a/tests/templates/globals-default.j2
+++ b/tests/templates/globals-default.j2
@@ -59,6 +59,8 @@ mariadb_wsrep_extra_provider_options:
 
 nova_compute_virt_type: "{{ virt_type }}"
 
+neutron_agents_wrappers: "yes"
+
 enable_openstack_core: "{{ openstack_core_enabled }}"
 enable_horizon: "{{ dashboard_enabled }}"
 enable_heat: "{{ openstack_core_tested }}"
@@ -154,6 +156,7 @@ enable_rabbitmq: "no"
 {% if scenario == "cephadm" %}
 # kolla-ansible vars
 enable_cinder: "yes"
+enable_neutron_agent_ha: "yes"
 # External Ceph
 glance_backend_ceph: "yes"
 cinder_backend_ceph: "yes"


### PR DESCRIPTION
It's an experimental feature, disabled by default (but enabled by default in our CI).

It's based on TripleO ,,version'' that was their fix for the linked bug.

Closes-Bug: #1891469

Depends-On: https://review.opendev.org/c/openstack/kolla/+/946215

Change-Id: Iaa1e687152db8351bc0e9b10e66f412860ac13a5