### PR TITLE
Fix missing bracket in opensearch output

### DIFF
--- a/ansible/roles/common/templates/conf/output/03-opensearch.conf.j2
+++ b/ansible/roles/common/templates/conf/output/03-opensearch.conf.j2
@@ -3,7 +3,7 @@
     @type copy
     <store>
        @type opensearch
-       host { opensearch_address }}
+       host {{ opensearch_address }}
        port {{ opensearch_port }}
        logstash_format true
        logstash_prefix apel


### PR DESCRIPTION
Trivial fix. Doesn't affect 2025.1.