### PR TITLE
prometheus: Fix Grafana blackbox endpoint checks

### DIFF
--- a/ansible/roles/prometheus/defaults/main.yml
+++ b/ansible/roles/prometheus/defaults/main.yml
@@ -320,8 +320,10 @@ prometheus_blackbox_exporter_endpoints_default:
     enabled: "{{ enable_etcd | bool }}"
   - endpoints:
       - "grafana:http_2xx:{{ grafana_public_endpoint }}"
-      - "{{ ('grafana_internal:http_2xx:' + grafana_internal_endpoint) if not kolla_same_external_internal_vip | bool }}"
-    enabled: "{{ enable_grafana | bool }}"
+    enabled: "{{ enable_grafana | bool and enable_grafana_external | bool }}"
+  - endpoints:
+      - "grafana_internal:http_2xx:{{ grafana_internal_endpoint }}"
+    enabled: "{{ enable_grafana | bool and ((not enable_grafana_external | bool) or (not kolla_same_external_internal_vip | bool)) }}"
   - endpoints:
       - "opensearch:http_2xx:{{ opensearch_internal_endpoint }}"
     enabled: "{{ enable_opensearch | bool }}"

--- a/releasenotes/notes/fix-grafana-external-blackbox-check-c1b97a2406ad3b15.yaml
+++ b/releasenotes/notes/fix-grafana-external-blackbox-check-c1b97a2406ad3b15.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes Prometheus blackbox exporter checks for Grafana when external
+    Grafana access is disabled. The public Grafana endpoint is now only
+    monitored when ``enable_grafana_external`` is enabled, while the internal
+    endpoint continues to be monitored when appropriate.


### PR DESCRIPTION
Split the Grafana blackbox endpoint into separate public and internal checks. The public endpoint is now only monitored when both Grafana and ``enable_grafana_external`` are enabled (which is the default when enabling Grafana), matching the HAProxy external listener check.

The internal endpoint remains monitored when Grafana is enabled and either external Grafana is disabled or the internal and external VIPs are separate. This avoids losing Grafana monitoring when ``enable_grafana_external`` is disabled.

Closes-Bug: #2157003
Change-Id: Iea3b21dcfa4284f2a74c1bee95577ce8a219cf5f