### PR TITLE
Set Ironic tempdir

### DIFF
--- a/ansible/roles/ironic/templates/ironic.conf.j2
+++ b/ansible/roles/ironic/templates/ironic.conf.j2
@@ -6,6 +6,9 @@ debug = {{ ironic_logging_debug }}
 
 log_dir = /var/log/kolla/ironic
 
+tempdir = /var/lib/ironic/tmp
+
+
 transport_url = {{ rpc_transport_url }}
 
 {% if pin_release_version is defined %}

--- a/releasenotes/notes/fix-bug-2156758-e536b254fdd3fd32.yaml
+++ b/releasenotes/notes/fix-bug-2156758-e536b254fdd3fd32.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes the Ironic temp directory causing invalid cross device links when
+    deploying baremetal images using the virtualmedia boot interface.


### PR DESCRIPTION
Set the Ironic tempdir to be within the Ironic Docker container volume.

Closes-Bug: #2156758
Depends-On: https://review.opendev.org/c/openstack/kolla/+/993769
Change-Id: Ib24a04657f297ebb323686aa1d80f9bf019f44f2

(cherry picked from commit ba5d4219749099cb7a797deb77685c5293fb9bf5)