### PR TITLE
Clone ansible-collection-kolla from GitHub (2024.1)

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,5 @@
 ---
 collections:
-  - name: https://opendev.org/openstack/ansible-collection-kolla
+  - name: https://github.com/openstack/ansible-collection-kolla
     type: git
     version: unmaintained/2024.1


### PR DESCRIPTION
This is to avoid Git clone issues caused by DoS protection.